### PR TITLE
Feat: 미션(퀴즈) 조회 기능 구현

### DIFF
--- a/src/main/java/com/antmillion/mission/controller/MissionController.java
+++ b/src/main/java/com/antmillion/mission/controller/MissionController.java
@@ -1,15 +1,30 @@
 package com.antmillion.mission.controller;
 
+import com.antmillion.mission.dto.QuizQuestionResponseDTO;
+import com.antmillion.mission.service.MissionService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/mission")
+@RequiredArgsConstructor
 public class MissionController {
+
+    private final MissionService missionService;
 
     @GetMapping
     public String missionPage() {
         return "mission/mission";
+    }
+
+    @GetMapping("/daily")
+    @ResponseBody
+    public List<QuizQuestionResponseDTO> getDailyQuizData() {
+        return missionService.getDailyQuiz();
     }
 }

--- a/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
+++ b/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
@@ -1,4 +1,4 @@
-package com.antmillion.mappers;
+package com.antmillion.mission.mapper;
 
 import com.antmillion.mission.dto.QuizChoiceDTO;
 import com.antmillion.mission.dto.QuizLogDTO;

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -1,0 +1,8 @@
+package com.antmillion.mission.service;
+
+import com.antmillion.mission.dto.QuizQuestionResponseDTO;
+import java.util.List;
+
+public interface MissionService {
+    List<QuizQuestionResponseDTO> getDailyQuiz();
+}

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -1,0 +1,67 @@
+package com.antmillion.mission.service;
+
+import com.antmillion.mission.dto.QuizChoiceDTO;
+import com.antmillion.mission.dto.QuizQuestionDTO;
+import com.antmillion.mission.dto.QuizQuestionResponseDTO;
+import com.antmillion.mission.mapper.MissionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MissionServiceImpl implements MissionService {
+    private final MissionMapper missionMapper;
+
+    @Override
+    public List<QuizQuestionResponseDTO> getDailyQuiz() {
+        // 오늘 날짜 구하기 (yyyy-MM-dd)
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        // 오늘의 퀴즈 문제(Question) 조회
+        List<QuizQuestionDTO> questions = missionMapper.selectQuizByDate(today);
+
+        // 퀴즈가 없으면 빈 리스트 반환 (에러 방지)
+        if (questions.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // 퀴즈 ID들만 추출 (보기 조회를 위해)
+        List<Long> quizIds = questions.stream()
+                .map(QuizQuestionDTO::getQuizId)
+                .collect(Collectors.toList());
+
+        // 해당 퀴즈들의 보기(Choice) 전체 조회
+        List<QuizChoiceDTO> choices = missionMapper.selectQuizChoicesByQuizIds(quizIds);
+
+        // 보기들을 quizId를 키(Key)로 하여 그룹화 (퀴즈 ID로 객관식 보기 찾기 가능)
+        Map<Long, List<QuizChoiceDTO>> choicesMap = choices.stream()
+                .collect(Collectors.groupingBy(QuizChoiceDTO::getQuizId));
+
+        // 결과 DTO (Question + Choices)
+        List<QuizQuestionResponseDTO> responseList = new ArrayList<>();
+
+        for (QuizQuestionDTO q : questions) {
+            // 해당 문제의 보기 리스트 가져오기 (없으면 빈 리스트)
+            List<QuizChoiceDTO> quizChoices = choicesMap.getOrDefault(q.getQuizId(), new ArrayList<>());
+
+            // ResponseDTO 생성
+            QuizQuestionResponseDTO responseDTO = QuizQuestionResponseDTO.builder()
+                    .quizId(q.getQuizId())
+                    .type(q.getType())
+                    .question(q.getQuestion())
+                    .point(q.getPoint())
+                    .quizDate(q.getQuizDate())
+                    .choices(quizChoices)
+                    .build();
+            responseList.add(responseDTO);
+        }
+        return responseList;
+    }
+}

--- a/src/main/resources/mappers/mission/MissionMapper.xml
+++ b/src/main/resources/mappers/mission/MissionMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.antmillion.mappers.MissionMapper">
+<mapper namespace="com.antmillion.mission.mapper.MissionMapper">
 
     <resultMap id="quizQuestionMap" type="com.antmillion.mission.dto.QuizQuestionDTO">
         <id property="quizId" column="quiz_id"/>

--- a/src/main/webapp/WEB-INF/views/main/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main/main.jsp
@@ -64,10 +64,10 @@
             <!-- 미션 카드 -->
             <div class="main-mission-card main-grid-mission">
                 <div class="main-mission-header">
-                    <h3>미션 : 경제 퀴즈 풀기</h3>
+                    <h3>미션 : 오늘의 경제 퀴즈 풀기</h3>
                 </div>
                 <p class="main-mission-description">OX 퀴즈 맞히고 100P 받아가세요!</p>
-                <button class="main-mission-button">도전하기</button>
+                <a href="${cpath}/mission" class="main-mission-button">도전하기</a>
             </div>
 
             <!-- 코스닥 카드 -->

--- a/src/main/webapp/WEB-INF/views/mission/mission.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/mission.jsp
@@ -10,14 +10,11 @@
 <link rel="stylesheet" href="${cpath}/resources/css/mission/mission.css">
 <link rel="stylesheet" href="${cpath}/resources/css/common/sidebar.css">
 <link rel="stylesheet" href="${cpath}/resources/css/common/header.css">
-
 </head>
 <body>
 	<div class="mission-app-container">
 		<%@ include file="../common/sidebar.jsp"%>
-
 		<%@ include file="../common/header.jsp"%>
-
 		<main class="mission-main-content">
 			<!-- 진행률 카드 -->
 			<div class="mission-progress-card">
@@ -35,7 +32,7 @@
 			<!-- 퀴즈 카드 -->
 			<div class="mission-quiz-card" id="mission-quizCard">
 				<div class="mission-quiz-header">
-					<h3 class="mission-quiz-date">1월 2일 금요일 경제 퀴즈</h3>
+					<h3 class="mission-quiz-date"></h3>
 					<!-- 포인트 메시지 -->
 					<div class="mission-points-message" id="mission-pointsMessage"
 						style="display: none;">100 포인트 획득하였습니다.</div>
@@ -80,7 +77,7 @@
 				<p class="mission-modal-message">퀴즈를 맞히고 똑똑한개미 랭크를 높여보세요!</p>
 			</div>
 		</div>
-
+		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 		<script src="${cpath}/resources/js/mission/mission.js"></script>
 	</div>
 </body>

--- a/src/main/webapp/resources/css/main/main.css
+++ b/src/main/webapp/resources/css/main/main.css
@@ -45,6 +45,14 @@ body {
     margin: 0 auto;
 }
 
+.main-mission-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    color: white;
+}
+
 @media (min-width: 1401px) {
     .main-grid-rank {
         grid-column: 1;

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -1,4 +1,3 @@
-// 퀴즈 데이터 (서버에서 AJAX로 가져올 예정)
 let quizData = [];
 let currentQuizIndex = 0;
 let correctAnswers = 0;
@@ -6,33 +5,55 @@ let isAnswering = false;
 
 // 페이지 로드 시 실행
 document.addEventListener('DOMContentLoaded', function () {
-    loadQuizData();
+    fetchDailyQuiz();
 });
 
-// 퀴즈 데이터 로드 (AJAX)
-function loadQuizData() {
-    // 임시 데이터
-    quizData = [
-        {
-            id: 1,
-            question: "위험을 줄이기 위해 자산을 여러 곳에 나누어 투자하는 원칙을 분산투자라고 한다.",
-            options: [
-                {id: 1, text: "O", isCorrect: true},
-                {id: 2, text: "X", isCorrect: false}
-            ]
+function formatTodayKorean() {
+    const today = new Date();
+    const month = today.getMonth() + 1;
+    const date = today.getDate();
+    const dayNames = ['일', '월', '화', '수', '목', '금', '토'];
+    const day = dayNames[today.getDay()];
+    return `${month}월 ${date}일 ${day}요일 오늘의 경제 퀴즈`;
+}
+
+// 서버 API 호출하여 데이터 가져오기
+function fetchDailyQuiz() {
+    $.ajax({
+        url: '/antmillion/mission/daily',
+        type: 'GET',
+        dataType: 'json',
+        success: function (data) {
+            if (!data || data.length === 0) {
+                alert("오늘의 퀴즈가 없습니다!");
+                return;
+            }
+
+            // 날짜 변경
+            const quizTitle = document.querySelector('.mission-quiz-date');
+            if (quizTitle) {
+                quizTitle.textContent = formatTodayKorean();
+            }
+
+            quizData = data.map(q => ({
+                id: q.quizId,
+                type: q.type,
+                question: q.question,
+                point: q.point,
+                options: q.choices.map((c, index) => ({
+                    id: c.quizChoiceId,
+                    text: c.choiceText,
+                    isCorrect: (index === 0)
+                }))
+            }));
+
+            currentQuizIndex = 0;
+            loadQuiz(currentQuizIndex);
         },
-        {
-            id: 2,
-            question: "주가가 하락할 때 주식을 빌려 파는 것은?",
-            options: [
-                {id: 3, text: "매수", isCorrect: false},
-                {id: 4, text: "공매도", isCorrect: true},
-                {id: 5, text: "손절매", isCorrect: false},
-                {id: 6, text: "물타기", isCorrect: false}
-            ]
+        error: function (xhr, status, error) {
+            console.error('퀴즈 데이터를 가져오는 중 오류 발생:', error);
         }
-    ];
-    loadQuiz(currentQuizIndex);
+    });
 }
 
 // 퀴즈 로드

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -43,6 +43,7 @@ function fetchDailyQuiz() {
                 options: q.choices.map((c, index) => ({
                     id: c.quizChoiceId,
                     text: c.choiceText,
+                    // 임시로 1번 보기를 정답으로 처리, 추후에 변경
                     isCorrect: (index === 0)
                 }))
             }));


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #96 

---

### 📝 작업 내용
[Backend]
- MissionService 인터페이스 정의
- MissionServiceImpl 클래스 생성 및 비즈니스 로직 구현
   - 오늘 날짜 기준 퀴즈 조회
   - 퀴즈 ID 기준 보기(Choice) 조회
   - QuizQuestionResponseDTO로 데이터 조립 (문제 + 보기)
- MissionController에 퀴즈 조회 API 엔드포인트 추가
[Frontend]
- mission.js 내 임시 데이터 제거 및 jQuery를 이용한 $.ajax API 호출 로직 구현
- 받아온 JSON 데이터를 기반으로 퀴즈 문제 및 보기 동적 렌더링

---

### 📷 테스트 방법
- 퀴즈 데이터 (슬랙에 올려놓았습니다.)
rank, member 임시 데이터, 퀴즈 데이터 넣고
http://localhost:8080/antmillion/mission/daily 에 접속하면 오늘의 퀴즈 데이터 조회 가능합니다.
아직 채점 로직이 완성되지 않은 상태이기 때문에 JS에서 임시로 1번 보기로 정답 처리하였습니다. 추후에 변경 예정입니다.

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
