### PR TITLE
Feat: 종목 상세 주문하기 매도 탭 UI 구현 및 종목 클릭 시 상세 페이지 이동

### DIFF
--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -1,5 +1,5 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
-	pageEncoding="UTF-8"%>
+    pageEncoding="UTF-8"%>
 <!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -12,101 +12,102 @@
 <link rel="stylesheet" href="${cpath}/resources/css/detail/community.css">
 </head>
 <body class="detail-body">
-	<div class="detail-container">
-		<%@ include file="../common/sidebar.jsp"%>
-		<main class="detail-main-content">
-			<%@ include file="../common/header.jsp"%>
-			<div class="detail-stock-container">
-				<div class="detail-left-panel">
-					<section class="detail-stock-header">
-						<img src="${cpath}/resources/images/icon/samsung.png" alt="삼성전자">
-						<div class="detail-text-col">
-							<div>
-								<h2 class="detail-stock-name">
-									삼성전자 <span class="stock-code">005930</span>
-								</h2>
-							</div>
-							<div class="detail-current-price">
-								<h3>129,300원</h3>
-							</div>
-						</div>
-						<div class="detail-star-icon">
-							<img src="${cpath}/resources/images/icon/star.png" alt="즐겨찾기">
-						</div>
-					</section>
+    <div class="detail-container">
+        <%@ include file="../common/sidebar.jsp"%>
+        <main class="detail-main-content">
+            <%@ include file="../common/header.jsp"%>
+            <div class="detail-stock-container">
+                <div class="detail-left-panel">
+                    <section class="detail-stock-header">
+                        <img src="${cpath}/resources/images/icon/samsung.png" alt="삼성전자">
+                        <div class="detail-text-col">
+                            <div>
+                                <h2 class="detail-stock-name">
+                                    삼성전자 <span class="stock-code">005930</span>
+                                </h2>
+                            </div>
+                            <div class="detail-current-price">
+                                <h3>129,300원</h3>
+                            </div>
+                        </div>
+                        <div class="detail-star-icon">
+                            <img src="${cpath}/resources/images/icon/star.png" alt="즐겨찾기">
+                        </div>
+                    </section>
 
-					<section class="detail-chart-area"></section>
-					<section class="detail-bottom-split">
-						<section class="detail-hoga-box">
-							<div class="detail-strong">
-								<h3>호가</h3>
-							</div>
-						</section>
-						<section class="detail-community-box">
-							<div class="detail-strong">
-								<h3>커뮤니티</h3>
-							</div>
+                    <section class="detail-chart-area"></section>
+                    <section class="detail-bottom-split">
+                        <section class="detail-hoga-box">
+                            <div class="detail-strong">
+                                <h3>호가</h3>
+                            </div>
+                        </section>
+                        <section class="detail-community-box">
+                            <div class="detail-strong">
+                                <h3>커뮤니티</h3>
+                            </div>
 
-							<!-- 커뮤니티 내용 include -->
-							<%@ include file="/WEB-INF/views/stock/community.jsp"%>
+                            <!-- 커뮤니티 내용 include -->
+                            <%@ include file="/WEB-INF/views/stock/community.jsp"%>
 
-						</section>
-					</section>
-				</div>
-				<aside class="detail-right-panel">
-					<div class="detail-order-top">
-						<h3>주문하기</h3>
-						<span class="detail-change-link">주문 방법 바꾸기</span>
-					</div>
-					<div class="detail-tab-group">
-						<button class="detail-tab-active">매수</button>
-						<button class="detail-tab">매도</button>
-						<button class="detail-tab">대기</button>
-					</div>
-					<div class="detail-input-card">
-						<div class="detail-row">
-							<span class="detail-card-label"> <span
-								class="detail-active-type">지정가</span> | <span>시장가</span>
-							</span> <span class="detail-big-price">129,300원</span>
-						</div>
-						<div class="detail-row">
-							<span>수량</span> <span class="detail-big-price">10주</span>
-						</div>
-					</div>
+                        </section>
+                    </section>
+                </div>
+                <aside class="detail-right-panel">
+                    <div class="detail-order-top">
+                        <h3>주문하기</h3>
+                        <span class="detail-change-link">주문 방법 바꾸기</span>
+                    </div>
+                    <div class="detail-tab-group">
+                        <button class="detail-tab-active" data-type="buy">매수</button>
+                        <button class="detail-tab" data-type="sell">매도</button>
+                        <button class="detail-tab" data-type="pending">대기</button>
+                    </div>
+                    <div class="detail-input-card">
+                        <div class="detail-row">
+                            <span class="detail-card-label"> <span
+                                class="detail-active-type">지정가</span> | <span>시장가</span>
+                            </span> <span class="detail-big-price">129,300원</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>수량</span> <span class="detail-big-price">10주</span>
+                        </div>
+                    </div>
 
-					<div class="detail-order-result">
-						<div class="detail-row">
-							<span>구매 가능 금액</span> <span class="detail-big-price"
-								class="detail-money">1,293,000원</span>
-						</div>
-						<div class="detail-row">
-							<span>내 주식 평균</span> <span class="detail-big-price"
-								class="detail-money">129,300원</span>
-						</div>
-						<div class="detail-total-row">
-							<span>주문금액</span> <span class="detail-big-price"
-								class="detail-total-money">1,293,000원</span>
-						</div>
-					</div>
-					<div class="detail-sentiment-section">
-						<div class="detail-sentiment-text">
-							🔥 현재 투자자 78%가 <span class="detail-red-text">매수</span>쪽으로 몰려요!
-						</div>
-						<div class="detail-percent-labels">
-							<div style="width: 78%;">78%</div>
-							<div style="width: 22%;">22%</div>
-						</div>
-						<div>
-							<div class="detail-progress-bar">
-								<div class="detail-fill-buy" style="width: 78%;"></div>
-								<div class="detail-fill-sell" style="width: 22%;"></div>
-							</div>
-						</div>
-					</div>
-					<button class="detail-btn-submit">매수</button>
-				</aside>
-			</div>
-		</main>
-	</div>
+                    <div class="detail-order-result">
+                        <div class="detail-row">
+                            <span id="available-label">구매 가능 금액</span> <span class="detail-big-price"
+                                class="detail-money">1,293,000원</span>
+                        </div>
+                        <div class="detail-row">
+                            <span>내 주식 평균</span> <span class="detail-big-price"
+                                class="detail-money">129,300원</span>
+                        </div>
+                        <div class="detail-total-row">
+                            <span>주문금액</span> <span class="detail-big-price"
+                                class="detail-total-money" id="total-money">1,293,000원</span>
+                        </div>
+                    </div>
+                    <div class="detail-sentiment-section">
+                        <div class="detail-sentiment-text">
+                            🔥 현재 투자자 <span id="sentiment-percent">78</span>%가 <span class="detail-red-text" id="sentiment-direction">매수</span>쪽으로 몰려요!
+                        </div>
+                        <div class="detail-percent-labels">
+                            <div style="width: 78%;" id="buy-percent">78%</div>
+                            <div style="width: 22%;" id="sell-percent">22%</div>
+                        </div>
+                        <div>
+                            <div class="detail-progress-bar">
+                                <div class="detail-fill-buy" style="width: 78%;" id="buy-bar"></div>
+                                <div class="detail-fill-sell" style="width: 22%;" id="sell-bar"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <button class="detail-btn-submit" id="submit-btn">매수</button>
+                </aside>
+            </div>
+        </main>
+    </div>
+<script src="${cpath}/resources/js/detail/detail.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/stocklist/stocklist.jsp
+++ b/src/main/webapp/WEB-INF/views/stocklist/stocklist.jsp
@@ -42,7 +42,10 @@
         </div>
     </main>
 </div>
-<script> const contextPath = '${cpath}'; </script>
+<script>
+    // contextPath 변수 설정 (stocklist.js에서 사용)
+    var contextPath = '${cpath}';
+</script>
 <script src="${cpath}/resources/js/stocklist/stocklist.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/css/detail/detail.css
+++ b/src/main/webapp/resources/css/detail/detail.css
@@ -302,6 +302,8 @@ body {
 
 .detail-red-text { color: var(--color-positive); }
 
+.detail-blue-text { color: var(--color-negative); }
+
 .detail-percent-labels {
 	display: flex;
 	justify-content: space-between;

--- a/src/main/webapp/resources/js/detail/community.js
+++ b/src/main/webapp/resources/js/detail/community.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
     const urlParams = new URLSearchParams(window.location.search);
-    const stockCode = urlParams.get('stockCode');
+    const stockCode = urlParams.get('code');
     
     if (!stockCode) {
         console.error('종목 코드가 없습니다.');
@@ -26,7 +26,7 @@ $(document).ready(function() {
 
 function loadCommunityList(stockCode) {
     $.ajax({
-        url: '/antmillion/community/list',
+        url: (typeof contextPath !== 'undefined' ? contextPath : '/antmillion') + '/community/list',
         type: 'GET',
         data: { stockCode: stockCode },
         success: function(response) {
@@ -86,7 +86,7 @@ function writeCommunity(stockCode) {
     }
     
     $.ajax({
-        url: '/antmillion/community/write',
+        url: (typeof contextPath !== 'undefined' ? contextPath : '/antmillion') + '/community/write',
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify({

--- a/src/main/webapp/resources/js/detail/detail.js
+++ b/src/main/webapp/resources/js/detail/detail.js
@@ -1,0 +1,60 @@
+// 탭 전환 기능
+document.querySelectorAll('.detail-tab, .detail-tab-active').forEach(tab => {
+    tab.addEventListener('click', function() {
+        const type = this.dataset.type;
+        if (type === 'pending') { 
+            alert('대기 주문 기능은 준비 중입니다.'); 
+            return; 
+        }
+        
+        // 모든 탭에서 active 클래스 제거
+        document.querySelectorAll('.detail-tab, .detail-tab-active').forEach(t => {
+            t.classList.remove('detail-tab-active');
+            t.classList.add('detail-tab');
+        });
+        
+        // 현재 클릭된 탭에 active 클래스 추가
+        this.classList.remove('detail-tab');
+        this.classList.add('detail-tab-active');
+        
+        const btn = document.getElementById('submit-btn');
+        const totalMoney = document.getElementById('total-money');
+        const availableLabel = document.getElementById('available-label');
+        const sentimentDir = document.getElementById('sentiment-direction');
+        const sentimentPercent = document.getElementById('sentiment-percent');
+        const buyPercent = document.getElementById('buy-percent');
+        const sellPercent = document.getElementById('sell-percent');
+        const buyBar = document.getElementById('buy-bar');
+        const sellBar = document.getElementById('sell-bar');
+        
+        if (type === 'buy') {
+            btn.textContent = '매수';
+            btn.style.background = '#e22939';
+            totalMoney.style.color = '#e22939';
+            availableLabel.textContent = '구매 가능 금액';
+            sentimentDir.textContent = '매수';
+            sentimentDir.className = 'detail-red-text';
+            sentimentPercent.textContent = '78';
+            buyPercent.textContent = '78%';
+            buyPercent.style.width = '78%';
+            sellPercent.textContent = '22%';
+            sellPercent.style.width = '22%';
+            buyBar.style.width = '78%';
+            sellBar.style.width = '22%';
+        } else if (type === 'sell') {
+            btn.textContent = '매도';
+            btn.style.background = '#2271e9';
+            totalMoney.style.color = '#2271e9';
+            availableLabel.textContent = '판매 가능 수량';
+            sentimentDir.textContent = '매도';
+            sentimentDir.className = 'detail-blue-text';
+            sentimentPercent.textContent = '22';
+            buyPercent.textContent = '22%';
+            buyPercent.style.width = '22%';
+            sellPercent.textContent = '78%';
+            sellPercent.style.width = '78%';
+            buyBar.style.width = '22%';
+            sellBar.style.width = '78%';
+        }
+    });
+});

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -1,17 +1,17 @@
 // Mock 데이터
 const allStocks = [
-    { id: 1, name: '삼성전자', logo: 'samsung', price: '140,900원', change: '+1.43%', isPositive: true, buyRatio: 50, sellRatio: 50, isFavorite: false },
-    { id: 2, name: 'SK하이닉스', logo: 'sk', price: '742,500원', change: '+2.27%', isPositive: true, buyRatio: 43, sellRatio: 57, isFavorite: true },
-    { id: 3, name: '현대차', logo: 'hyundai', price: '326,500원', change: '+6.00%', isPositive: true, buyRatio: 75, sellRatio: 25, isFavorite: false },
-    { id: 4, name: '한미반도체', logo: 'hanmi', price: '186,300원', change: '+1.41%', isPositive: true, buyRatio: 41, sellRatio: 59, isFavorite: false },
-    { id: 5, name: 'KODEX 레버리지', logo: 'kodex', price: '57,300원', change: '+1.64%', isPositive: true, buyRatio: 44, sellRatio: 56, isFavorite: false },
-    { id: 6, name: '두산에너빌리티', logo: 'doosan', price: '84,900원', change: '-1.16%', isPositive: false, buyRatio: 57, sellRatio: 43, isFavorite: true },
-    { id: 7, name: '한화오션', logo: 'hanwha', price: '123,500원', change: '+3.08%', isPositive: true, buyRatio: 66, sellRatio: 34, isFavorite: false },
-    { id: 8, name: 'KODEX 200', logo: 'kodex', price: '66,765원', change: '+0.83%', isPositive: true, buyRatio: 29, sellRatio: 71, isFavorite: false },
-    { id: 9, name: '현대오토에버', logo: 'hyundai-motor', price: '336,000원', change: '+7.69%', isPositive: true, buyRatio: 66, sellRatio: 34, isFavorite: true },
-    { id: 10, name: 'KODEX 200선물...', logo: 'kodex', price: '509원', change: '-1.54%', isPositive: false, buyRatio: 44, sellRatio: 56, isFavorite: false },
-    { id: 11, name: 'SFA반도체', logo: 'sfa', price: '6,090원', change: '+8.17%', isPositive: true, buyRatio: 46, sellRatio: 54, isFavorite: false },
-    { id: 12, name: 'NAVER', logo: 'naver', price: '255,000원', change: '-1.92%', isPositive: false, buyRatio: 52, sellRatio: 48, isFavorite: true }
+    { id: 1, name: '삼성전자', code: '005930', logo: 'samsung', price: '140,900원', change: '+1.43%', isPositive: true, buyRatio: 50, sellRatio: 50, isFavorite: false },
+    { id: 2, name: 'SK하이닉스', code: '000660', logo: 'sk', price: '742,500원', change: '+2.27%', isPositive: true, buyRatio: 43, sellRatio: 57, isFavorite: true },
+    { id: 3, name: '현대차', code: '005380', logo: 'hyundai', price: '326,500원', change: '+6.00%', isPositive: true, buyRatio: 75, sellRatio: 25, isFavorite: false },
+    { id: 4, name: '한미반도체', code: '042700', logo: 'hanmi', price: '186,300원', change: '+1.41%', isPositive: true, buyRatio: 41, sellRatio: 59, isFavorite: false },
+    { id: 5, name: 'KODEX 레버리지', code: '122630', logo: 'kodex', price: '57,300원', change: '+1.64%', isPositive: true, buyRatio: 44, sellRatio: 56, isFavorite: false },
+    { id: 6, name: '두산에너빌리티', code: '034020', logo: 'doosan', price: '84,900원', change: '-1.16%', isPositive: false, buyRatio: 57, sellRatio: 43, isFavorite: true },
+    { id: 7, name: '한화오션', code: '042660', logo: 'hanwha', price: '123,500원', change: '+3.08%', isPositive: true, buyRatio: 66, sellRatio: 34, isFavorite: false },
+    { id: 8, name: 'KODEX 200', code: '069500', logo: 'kodex', price: '66,765원', change: '+0.83%', isPositive: true, buyRatio: 29, sellRatio: 71, isFavorite: false },
+    { id: 9, name: '현대오토에버', code: '307950', logo: 'hyundai-motor', price: '336,000원', change: '+7.69%', isPositive: true, buyRatio: 66, sellRatio: 34, isFavorite: true },
+    { id: 10, name: 'KODEX 200선물...', code: '252670', logo: 'kodex', price: '509원', change: '-1.54%', isPositive: false, buyRatio: 44, sellRatio: 56, isFavorite: false },
+    { id: 11, name: 'SFA반도체', code: '036540', logo: 'sfa', price: '6,090원', change: '+8.17%', isPositive: true, buyRatio: 46, sellRatio: 54, isFavorite: false },
+    { id: 12, name: 'NAVER', code: '035420', logo: 'naver', price: '255,000원', change: '-1.92%', isPositive: false, buyRatio: 52, sellRatio: 48, isFavorite: true }
 ];
 
 let currentTab = 'all';
@@ -38,7 +38,7 @@ function createStockItemHTML(stock, index) {
     const logoUrl = logoMap[stock.logo] || 'https://via.placeholder.com/40?text=LOGO';
 
     return `
-        <div class="stocklist-item" data-id="${stock.id}">
+        <div class="stocklist-item" data-id="${stock.id}" data-code="${stock.code}">
             <div class="stocklist-favorite">
                 <span class="stocklist-rank">${index + 1}</span>
                 <button class="stocklist-favorite-btn ${favoriteClass}" data-id="${stock.id}">${favoriteIcon}</button>
@@ -153,8 +153,17 @@ function attachStockItemListeners() {
                 return;
             }
 
-            // contextPath는 JSP에서 전역 변수로 설정되어 있음
-            window.location.href = contextPath + '/stock/detail';
+            // 종목 코드 가져오기
+            const code = this.dataset.code;
+            
+            // contextPath 체크
+            if (typeof contextPath === 'undefined') {
+                console.error('contextPath가 정의되지 않았습니다!');
+                // contextPath가 없으면 상대 경로 사용
+                window.location.href = '/antmillion/stock/detail?code=' + code;
+            } else {
+                window.location.href = contextPath + '/stock/detail?code=' + code;
+            }
         });
     });
 }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #104 

---

### 📝 작업 내용
종목 상세 페이지 주문하기 영역에 매수 / 매도 탭 전환 UI 추가
탭 선택에 따라 매수·매도 UI가 전환되도록 화면 구조 구성
종목 리스트에서 종목 클릭 시 stockCode 파라미터 기반 상세 페이지 이동
종목 상세 페이지에서 해당 종목 코드 기준 커뮤니티 조회 및 작성 연동

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [x] PR 제목 규칙을 지켰다
- [x] 추가/수정 사항을 설명했다
- [x] 이슈 번호를 연결했다
