### PR TITLE
Feat: 미션(퀴즈) 정답 채점 및 로그 저장 기능 구현

### DIFF
--- a/src/main/java/com/antmillion/mission/controller/MissionController.java
+++ b/src/main/java/com/antmillion/mission/controller/MissionController.java
@@ -1,12 +1,11 @@
 package com.antmillion.mission.controller;
 
 import com.antmillion.mission.dto.QuizQuestionResponseDTO;
+import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
 import com.antmillion.mission.service.MissionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -26,5 +25,11 @@ public class MissionController {
     @ResponseBody
     public List<QuizQuestionResponseDTO> getDailyQuizData() {
         return missionService.getDailyQuiz();
+    }
+
+    @PostMapping("/check")
+    @ResponseBody
+    public boolean checkAnswer(@RequestBody QuizSubmissionRequestDTO requestDTO) {
+        return missionService.checkAndLogAnswer(requestDTO);
     }
 }

--- a/src/main/java/com/antmillion/mission/dto/QuizSubmissionRequestDTO.java
+++ b/src/main/java/com/antmillion/mission/dto/QuizSubmissionRequestDTO.java
@@ -1,0 +1,13 @@
+package com.antmillion.mission.dto;
+
+import lombok.*;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class QuizSubmissionRequestDTO {
+    private Long userId;
+    private Long quizId;
+    private Integer choiceNo;
+}

--- a/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
+++ b/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
@@ -27,4 +27,10 @@ public interface MissionMapper {
 
     // 어떤 문제를 풀었는지 확인
     List<Long> selectTodaySolvedQuizIds(@Param("userId") Long userId);
+
+    // 사용자 포인트 조회
+    int selectQuizPointByQuizId(@Param("quizId") Long quizId);
+
+    // 포인트 지급
+    void updateUserPoint(@Param("userId") Long userId, @Param("point") Integer point);
 }

--- a/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
+++ b/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
@@ -20,8 +20,11 @@ public interface MissionMapper {
     int countSolvedHistory(@Param("userId") Long userId, @Param("quizId") Long quizId);
 
     // 퀴즈 풀이 이력 저장
-    int insertQuizLog(QuizLogDTO quizLog);
+    void insertQuizLog(QuizLogDTO quizLog);
 
     // 오늘 맞춘 문제 개수 조회
     int countTodaySolved(@Param("userId") Long userId);
+
+    // 정답 번호 조회
+    Integer selectAnswerByQuizId(@Param("quizId") Long quizId);
 }

--- a/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
+++ b/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
@@ -22,9 +22,9 @@ public interface MissionMapper {
     // 퀴즈 풀이 이력 저장
     void insertQuizLog(QuizLogDTO quizLog);
 
-    // 오늘 맞춘 문제 개수 조회
-    int countTodaySolved(@Param("userId") Long userId);
-
     // 정답 번호 조회
     Integer selectAnswerByQuizId(@Param("quizId") Long quizId);
+
+    // 어떤 문제를 풀었는지 확인
+    List<Long> selectTodaySolvedQuizIds(@Param("userId") Long userId);
 }

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -1,8 +1,10 @@
 package com.antmillion.mission.service;
 
 import com.antmillion.mission.dto.QuizQuestionResponseDTO;
+import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
 import java.util.List;
 
 public interface MissionService {
     List<QuizQuestionResponseDTO> getDailyQuiz();
+    boolean checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO);
 }

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -1,11 +1,10 @@
 package com.antmillion.mission.service;
 
-import com.antmillion.mission.dto.QuizChoiceDTO;
-import com.antmillion.mission.dto.QuizQuestionDTO;
-import com.antmillion.mission.dto.QuizQuestionResponseDTO;
+import com.antmillion.mission.dto.*;
 import com.antmillion.mission.mapper.MissionMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -63,5 +62,29 @@ public class MissionServiceImpl implements MissionService {
             responseList.add(responseDTO);
         }
         return responseList;
+    }
+
+    @Override
+    @Transactional
+    public boolean checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO) {
+        // 해당 퀴즈의 정답 조회
+        Integer realAnswer = missionMapper.selectAnswerByQuizId(requestDTO.getQuizId());
+        if (realAnswer == null) {
+            throw new IllegalArgumentException("존재하지 않는 퀴즈입니다.");
+        }
+
+        // 채점
+        boolean isCorrect = realAnswer.equals(requestDTO.getChoiceNo());
+        if(isCorrect) {
+            int count = missionMapper.countSolvedHistory(requestDTO.getUserId(), requestDTO.getQuizId());
+            if (count == 0) {
+                QuizLogDTO logDTO = QuizLogDTO.builder()
+                        .userId(requestDTO.getUserId())
+                        .quizId(requestDTO.getQuizId())
+                        .build();
+                missionMapper.insertQuizLog(logDTO);
+            }
+        }
+        return isCorrect;
     }
 }

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -33,14 +33,20 @@ public class MissionServiceImpl implements MissionService {
             return new ArrayList<>();
         }
 
-        // 오늘 미션 완료 했는지 확인
-        int solvedCount = missionMapper.countTodaySolved(userId);
-        if (solvedCount >= questions.size()) {
+        List<Long> solvedQuizIds = missionMapper.selectTodaySolvedQuizIds(userId);
+
+        // 안 푼 문제만 필터링
+        List<QuizQuestionDTO> unsolvedQuestions = questions.stream()
+                .filter(q -> !solvedQuizIds.contains(q.getQuizId()))
+                .collect(Collectors.toList());
+
+        // 오늘 미션 완료면 빈 리스트 반환 (에러 방지)
+        if (unsolvedQuestions.isEmpty()) {
             return new ArrayList<>();
         }
 
         // 퀴즈 ID들만 추출 (보기 조회를 위해)
-        List<Long> quizIds = questions.stream()
+        List<Long> quizIds = unsolvedQuestions.stream()
                 .map(QuizQuestionDTO::getQuizId)
                 .collect(Collectors.toList());
 
@@ -54,7 +60,7 @@ public class MissionServiceImpl implements MissionService {
         // 결과 DTO (Question + Choices)
         List<QuizQuestionResponseDTO> responseList = new ArrayList<>();
 
-        for (QuizQuestionDTO q : questions) {
+        for (QuizQuestionDTO q : unsolvedQuestions) {
             // 해당 문제의 보기 리스트 가져오기 (없으면 빈 리스트)
             List<QuizChoiceDTO> quizChoices = choicesMap.getOrDefault(q.getQuizId(), new ArrayList<>());
 

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -97,6 +97,12 @@ public class MissionServiceImpl implements MissionService {
                         .quizId(requestDTO.getQuizId())
                         .build();
                 missionMapper.insertQuizLog(logDTO);
+
+                // 포인트 조회
+                int quizPoint = missionMapper.selectQuizPointByQuizId(requestDTO.getQuizId());
+
+                // 포인트 지급
+                missionMapper.updateUserPoint(requestDTO.getUserId(),  quizPoint);
             }
         }
         return isCorrect;

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -20,6 +20,8 @@ public class MissionServiceImpl implements MissionService {
 
     @Override
     public List<QuizQuestionResponseDTO> getDailyQuiz() {
+        Long userId = 1L;
+
         // 오늘 날짜 구하기 (yyyy-MM-dd)
         String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
@@ -28,6 +30,12 @@ public class MissionServiceImpl implements MissionService {
 
         // 퀴즈가 없으면 빈 리스트 반환 (에러 방지)
         if (questions.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // 오늘 미션 완료 했는지 확인
+        int solvedCount = missionMapper.countTodaySolved(userId);
+        if (solvedCount >= questions.size()) {
             return new ArrayList<>();
         }
 

--- a/src/main/resources/mappers/mission/MissionMapper.xml
+++ b/src/main/resources/mappers/mission/MissionMapper.xml
@@ -61,8 +61,8 @@
         WHERE user_id = #{userId} AND quiz_id = #{quizId}
     </select>
 
-    <select id="countTodaySolved" resultType="int">
-        SELECT COUNT(*)
+    <select id="selectTodaySolvedQuizIds" resultType="long">
+        SELECT quiz_id
         FROM quiz_log
         WHERE user_id = #{userId}
         AND DATE_FORMAT(solved_at, '%Y-%m-%d') = CURDATE()

--- a/src/main/resources/mappers/mission/MissionMapper.xml
+++ b/src/main/resources/mappers/mission/MissionMapper.xml
@@ -73,4 +73,15 @@
         FROM quiz_question
         WHERE quiz_id = #{quizId}
     </select>
+
+    <select id="selectQuizPointByQuizId" resultType="int">
+        SELECT point
+        FROM quiz_question
+        WHERE quiz_id = #{quizId}
+    </select>
+
+    <update id="updateUserPoint">
+        UPDATE member SET point = point + #{point}
+        WHERE user_id = #{userId}
+    </update>
 </mapper>

--- a/src/main/resources/mappers/mission/MissionMapper.xml
+++ b/src/main/resources/mappers/mission/MissionMapper.xml
@@ -67,4 +67,10 @@
         WHERE user_id = #{userId}
         AND DATE_FORMAT(solved_at, '%Y-%m-%d') = CURDATE()
     </select>
+
+    <select id="selectAnswerByQuizId" resultType="Integer">
+        SELECT answer
+        FROM quiz_question
+        WHERE quiz_id = #{quizId}
+    </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/mission/mission.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/mission.jsp
@@ -78,6 +78,9 @@
 			</div>
 		</div>
 		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+		<script>
+			const cpath = "${pageContext.request.contextPath}";
+		</script>
 		<script src="${cpath}/resources/js/mission/mission.js"></script>
 	</div>
 </body>

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -20,7 +20,7 @@ function formatTodayKorean() {
 // 서버 API 호출하여 데이터 가져오기
 function getDailyQuiz() {
     $.ajax({
-        url: '/antmillion/mission/daily',
+        url: cpath + '/mission/daily',
         type: 'GET',
         dataType: 'json',
         success: function (data) {
@@ -195,7 +195,7 @@ function submitAnswer(quizId, optionId, buttonElement) {
         choiceNo : optionId
     }
     $.ajax({
-        url: '/antmillion/mission/check',
+        url: cpath + '/mission/check',
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify(requestData),

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -25,7 +25,7 @@ function getDailyQuiz() {
         dataType: 'json',
         success: function (data) {
             if (!data || data.length === 0) {
-                alert("오늘의 퀴즈가 없습니다!");
+                showCompletion();
                 return;
             }
 

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -5,7 +5,7 @@ let isAnswering = false;
 
 // 페이지 로드 시 실행
 document.addEventListener('DOMContentLoaded', function () {
-    fetchDailyQuiz();
+    getDailyQuiz();
 });
 
 function formatTodayKorean() {
@@ -18,7 +18,7 @@ function formatTodayKorean() {
 }
 
 // 서버 API 호출하여 데이터 가져오기
-function fetchDailyQuiz() {
+function getDailyQuiz() {
     $.ajax({
         url: '/antmillion/mission/daily',
         type: 'GET',
@@ -42,9 +42,8 @@ function fetchDailyQuiz() {
                 point: q.point,
                 options: q.choices.map((c, index) => ({
                     id: c.quizChoiceId,
+                    no: c.choiceNo,
                     text: c.choiceText,
-                    // 임시로 1번 보기를 정답으로 처리, 추후에 변경
-                    isCorrect: (index === 0)
                 }))
             }));
 
@@ -75,8 +74,7 @@ function loadQuiz(index) {
         button.className = 'mission-option-btn';
         button.textContent = option.text;
         button.setAttribute('data-option-id', option.id);
-        button.setAttribute('data-is-correct', option.isCorrect);
-        button.onclick = () => selectOption(option.id, option.isCorrect, button);
+        button.onclick = () => selectOption(option.no, null, button);
         optionsContainer.appendChild(button);
     });
 
@@ -84,17 +82,15 @@ function loadQuiz(index) {
 }
 
 // 선택지 선택
-function selectOption(optionId, isCorrect, buttonElement) {
+function selectOption(optionId, ignore, buttonElement) {
     if (isAnswering) return;
     isAnswering = true;
 
-    if (isCorrect) {
-        // 정답 처리
-        handleCorrectAnswer(buttonElement, optionId);
-    } else {
-        // 오답 처리
-        handleWrongAnswer(buttonElement);
-    }
+    // 현재 퀴즈ID 가져오기
+    const currentQuizId = quizData[currentQuizIndex].id;
+
+    // 서버로 정답 제출 및 채점 요청
+    submitAnswer(currentQuizId, optionId, buttonElement);
 }
 
 // 정답 처리
@@ -107,9 +103,6 @@ function handleCorrectAnswer(buttonElement, optionId) {
 
     // 진행률 업데이트
     updateProgress();
-
-    // 서버에 정답 전송 (AJAX)
-    submitAnswer(quizData[currentQuizIndex].id, optionId, true);
 
     // 화면 클릭 시 즉시 다음 문제로
     const skipHandler = function () {
@@ -195,8 +188,31 @@ function showCompletion() {
 }
 
 // 정답 제출 (AJAX)
-function submitAnswer(quizId, optionId, isCorrect) {
-    console.log('Submit answer:', {quizId, optionId, isCorrect});
+function submitAnswer(quizId, optionId, buttonElement) {
+    const requestData = {
+        userId : 1, // 세션 ID로 변경 필요
+        quizId : quizId,
+        choiceNo : optionId
+    }
+    $.ajax({
+        url: '/antmillion/mission/check',
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify(requestData),
+        dataType: 'json',
+        success: function (isCorrect) {
+            if (isCorrect){
+                handleCorrectAnswer(buttonElement, optionId);
+            } else {
+                handleWrongAnswer(buttonElement);
+            }
+        },
+        error: function(xhr, status, error) {
+            console.error('채점 요청 실패:', error);
+            alert("채점 중 오류가 발생했습니다.");
+            isAnswering = false; // 에러 시 다시 클릭 가능
+        }
+    })
 }
 
 // 퀴즈 완료 제출


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #101 

---

### 📝 작업 내용
- 미션(오늘의 경제 퀴즈) 기능 전반에 대해 정답 채점, 풀이 로그 저장, 포인트 지급, 완료 처리까지의 전체 흐름을 구현했습니다.
- 기존 JS에서의 채점 방식과 count 기반 완료 판단 로직을 제거하고, 서버에서 실제 풀이 이력을 기준으로 처리하도록 수정했습니다.
[Backend]
- MissionMapper에 퀴즈 정답 조회, 오늘 푼 퀴즈 ID 목록 조회, 포인트 지급 관련 쿼리를 추가했습니다.
- MissionServiceImpl에서 사용자 제출 답안과 DB 정답을 비교하여 채점하고, 정답이면서 최초 풀이인 경우에만 로그 저장 및 포인트를 지급하도록 구현했습니다.
- 오늘 푼 퀴즈 ID 목록을 기준으로 이미 푼 문제를 제외하여 미해결 퀴즈만 반환하도록 로직을 개선했습니다.
- /mission/check 채점 API를 추가하여 서버에서 채점 결과를 반환하도록 구성했습니다.
[Frontend]
- 퀴즈 정답 판단 데이터를 제거하고 선택 시 즉시 서버 채점 API를 호출하도록 수정했습니다.
- 서버로부터 퀴즈 목록이 비어 있는 경우 미션 완료로 판단하여 완료 화면을 자동 전환되도록 처리했습니다.
- AJAX 요청 URL을 contextPath 기반으로 수정하여 안정적으로 동작하도록 개선했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
