### PR TITLE
Feat: 종목 상세페이지의 차트에 분/일/주/월/년 선택 조회 적용

### DIFF
--- a/src/main/webapp/WEB-INF/views/main/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main/main.jsp
@@ -49,11 +49,11 @@
                         <p class="main-market-index-symbol">KOSPI</p>
                     </div>
                 </div>
-                <div class="main-market-index-price">현재 수치</div>
+                <div class="main-market-index-price"></div>
                 <div class="main-market-index-change">
-                    <span class="main-change-label">전일대비</span>
-                    <span class="main-change-value main-positive">전일대비 금액</span>
-                    <span class="main-change-percent main-positive">전일대비 등락률</span>
+                    <span class="main-change-label"></span>
+                    <span class="main-change-value main-positive"></span>
+                    <span class="main-change-percent main-positive"></span>
                 </div>
                 <div class="main-market-index-chart" id="main-kospi-chart"></div>
             </div>
@@ -76,11 +76,11 @@
                         <p class="main-market-index-symbol">KOSDAQ</p>
                     </div>
                 </div>
-                <div class="main-market-index-price">현재 수치</div>
+                <div class="main-market-index-price"></div>
                 <div class="main-market-index-change">
-                    <span class="main-change-label">전일대비</span>
-                    <span class="main-change-value main-positive">전일대비 금액</span>
-                    <span class="main-change-percent main-positive">전일대비 등락률</span>
+                    <span class="main-change-label"></span>
+                    <span class="main-change-value main-positive"></span>
+                    <span class="main-change-percent main-positive"></span>
                 </div>
                 <div class="main-market-index-chart" id="main-kosdaq-chart"></div>
             </div>
@@ -107,8 +107,8 @@
                 <!-- 주식 차트 -->
 				<div class="main-stock-chart-card">
 				    <div class="main-chart-header">
-				        <h3 class="main-chart-stock-name" id="displayStockName">삼성전자</h3>
-				        <p class="main-chart-stock-code" id="displayStockCode">005930</p>
+				        <h3 class="main-chart-stock-name" id="displayStockName"></h3>
+				        <p class="main-chart-stock-code" id="displayStockCode"></p>
 				    </div>
 				    <div class="main-stock-chart-container" style="width: 100%; height: 400px;">
 				        <div id="main-stockChart" style="width: 100%; height: 100%;"></div>

--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -27,7 +27,7 @@
                                 </h2>
                             </div>
                             <div class="detail-current-price">
-                                <h3>129,300원</h3>
+                                <h3 id="detail-current-price-h3"></h3>
                             </div>
                         </div>
                         <button class="detail-favorite-btn" data-code="${stock.stockCode}">

--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -36,7 +36,15 @@
                     </section>
 
                     <section class="detail-chart-area">
-					    <div id="detail-stockChart" style="width: 100%; height: 100%;"></div>
+                        <!-- 차트 기간 선택 버튼 추가 -->
+                        <div class="detail-chart-period-buttons">
+                            <button class="detail-period-btn detail-period-active" data-period="minute">분</button>
+                            <button class="detail-period-btn" data-period="D">일</button>
+                            <button class="detail-period-btn" data-period="W">주</button>
+                            <button class="detail-period-btn" data-period="M">월</button>
+                            <button class="detail-period-btn" data-period="Y">년</button>
+                        </div>
+					    <div id="detail-stockChart" style="width: 100%; height: 280px;"></div>
 					</section>
                     <section class="detail-bottom-split">
                         <section class="detail-hoga-box">

--- a/src/main/webapp/resources/css/stock/detail.css
+++ b/src/main/webapp/resources/css/stock/detail.css
@@ -145,7 +145,7 @@ body {
 
 /* 차트 영역 */
 .detail-chart-area {
-	height: 400px;
+	height: 350px;
 	width: 100%;
 	position: relative;
 	background-color: #ffffff;
@@ -163,7 +163,7 @@ body {
 /* 차트 내부 영역 */
 #detail-stockChart {
     width: 100%;
-    height: 100%;
+    flex: 1;
 }
 
 /* Lightweight charts 로고 삭제 */
@@ -404,7 +404,7 @@ body {
 
 	/* 차트 높이 조정 */
 	.detail-chart-area {
-		height: 450px;
+		height: 350px;
 	}
 }
 
@@ -450,7 +450,7 @@ body {
 	}
 
 	.detail-chart-area {
-		height: 350px;
+		height: 300px;
 	}
 }
 
@@ -467,4 +467,33 @@ body {
 		align-items: flex-start;
 		gap: 12px;
 	}
+}
+
+.detail-chart-period-buttons {
+	display: flex;
+	gap: 8px;
+	padding: 8px 10px;
+	flex-shrink: 0;
+	border-radius: 8px 8px 0 0;
+	border-bottom: 1px solid var(--border-color);
+}
+
+.detail-period-btn {
+	padding: 8px 16px;
+	border: 1px solid #ddd;
+	background-color: white;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 14px;
+	transition: all 0.3s;
+}
+
+.detail-period-btn:hover {
+	background-color: #f0f0f0;
+}
+
+.detail-period-active {
+	background-color: #2271e9;
+	color: white;
+	border-color: #2271e9;
 }

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -15,6 +15,7 @@ function formatDate(yyyymmdd) {
 function createMainStockItemHTML(stock, index) {
     const favoriteIcon = stock.isFavorite ? '♥' : '♡';
     const favoriteClass = stock.isFavorite ? 'active' : '';
+    const currentPrice = Number(stock.stck_prpr).toLocaleString('ko-KR') + '원';
 
     return `
         <div class="main-stocklist-item" data-id="${stock.mksc_shrn_iscd}">
@@ -28,7 +29,7 @@ function createMainStockItemHTML(stock, index) {
                 </div>
                 <span class="main-stocklist-name">${stock.hts_kor_isnm}</span>
             </div>
-            <div class="main-stocklist-price">${stock.stck_prpr}</div>
+            <div class="main-stocklist-price">${currentPrice}</div>
             <div class="main-stocklist-change">${stock.acml_vol}</div>
             <div class="main-stocklist-sentiment">
                 <div class="main-stocklist-sentiment-bar">
@@ -80,6 +81,9 @@ function renderMainStocks() {
                         if (chartStockCode) {
                             chartStockCode.textContent = firstStock.mksc_shrn_iscd;
                         }
+
+                        //1번 항목의 차트 그리기
+                        drawStockMinuteChart(firstStock.mksc_shrn_iscd);
                     }
                 });
         });
@@ -405,20 +409,6 @@ document.addEventListener('mouseover', (e) => {
                 drawStockMinuteChart(stockCode);
             }
         }
-    }
-});
-
-// 페이지 로드 시 실행
-document.addEventListener('DOMContentLoaded', () => {
-    // HTML 헤더에 이미 적혀있는 종목 코드를 읽어옴
-    const defaultCodeEl = document.getElementById('displayStockCode');
-    
-    if (defaultCodeEl) {
-        const defaultStockCode = defaultCodeEl.textContent.trim();
-        console.log("초기 종목 코드 로드:", defaultStockCode);
-        
-        // 읽어온 코드로 차트 그리기 실행
-        drawStockMinuteChart(defaultStockCode);
     }
 });
 

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -146,6 +146,84 @@ function drawDetailChart(stockCode) {
     .catch(err => console.error("API 호출 에러:", err));
 }
 
+// 날짜 포맷 변경 (main.js의 formatDate 함수와 동일)
+function formatDate(yyyymmdd) {
+    return {
+        year: Number(yyyymmdd.substring(0, 4)),
+        month: Number(yyyymmdd.substring(4, 6)),
+        day: Number(yyyymmdd.substring(6, 8)),
+    };
+}
+
+// 일/주/월/년봉 차트 그리기 함수
+function drawPeriodChart(stockCode, period) {
+    const chartContainer = document.getElementById('detail-stockChart');
+    if (!chartContainer) {
+        console.error("#detail-stockChart 요소를 찾을 수 없음");
+        return;
+    }
+
+    chartContainer.innerHTML = ''; // 기존 차트 삭제
+
+    const width = chartContainer.clientWidth;
+    const height = chartContainer.clientHeight;
+
+    stockChart = LightweightCharts.createChart(chartContainer, {
+        width: width,
+        height: height,
+        layout: {
+            background: {type: 'solid', color: 'white'},
+            textColor: 'black'
+        },
+        grid: {
+            vertLines: { color: '#eee' },
+            horzLines: { color: '#eee' }
+        },
+        timeScale: {
+            borderColor: '#cccccc',
+            timeVisible: false,
+            secondsVisible: false
+        }
+    });
+
+    candleSeries = stockChart.addSeries(LightweightCharts.CandlestickSeries, {
+        upColor: '#e74c3c',
+        downColor: '#3498db',
+        borderUpColor: '#e74c3c',
+        borderDownColor: '#3498db',
+        wickUpColor: '#e74c3c',
+        wickDownColor: '#3498db'
+    });
+
+    // API 호출
+    fetch(`/antmillion/api/kis/periodChart/${stockCode}?period=${period}`)
+        .then(res => res.json())
+        .then(data => {
+            if (!data || data.length === 0) {
+                console.error("데이터가 비어있음");
+                return;
+            }
+
+            // 데이터 정렬
+            data.sort((a, b) => a.stck_bsop_date.localeCompare(b.stck_bsop_date));
+
+            // 차트 데이터 변환
+            const chartData = data.map(row => ({
+                time: formatDate(row.stck_bsop_date),
+                open: Number(row.stck_oprc),
+                high: Number(row.stck_hgpr),
+                low: Number(row.stck_lwpr),
+                close: Number(row.stck_clpr)
+            }));
+
+            if (chartData.length > 0) {
+                candleSeries.setData(chartData);
+                stockChart.timeScale().fitContent();
+            }
+        })
+        .catch(err => console.error("API 호출 에러:", err));
+}
+
 // 페이지 로드 시 실행
 document.addEventListener('DOMContentLoaded', () => {
     const urlParams = new URLSearchParams(window.location.search);
@@ -153,6 +231,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
     if (stockCode) {
         drawDetailChart(stockCode);
+
+        // 차트 기간 버튼 이벤트 리스너 추가
+        const periodButtons = document.querySelectorAll('.detail-period-btn');
+        periodButtons.forEach(btn => {
+            btn.addEventListener('click', function() {
+                // 모든 버튼에서 active 클래스 제거
+                periodButtons.forEach(b => b.classList.remove('detail-period-active'));
+
+                // 클릭된 버튼에 active 클래스 추가
+                this.classList.add('detail-period-active');
+
+                const period = this.getAttribute('data-period');
+
+                if (period === 'minute') {
+                    // 분봉 차트
+                    drawDetailChart(stockCode);
+                } else {
+                    // 일/주/월/년봉 차트
+                    drawPeriodChart(stockCode, period);
+                }
+            });
+        });
     } else {
         console.error("URL에 종목 코드가 없습니다.");
     }
@@ -161,7 +261,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // 반응형 대응
 window.addEventListener('resize', () => {
     if (stockChart) {
-        const container = document.querySelector('.detail-chart-area');
+        const container = document.querySelector('#detail-stockChart');
         stockChart.resize(container.clientWidth, container.clientHeight);
     }
 });

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -111,6 +111,9 @@ function drawDetailChart(stockCode) {
             return;
         }
 
+        const currentPrice = document.getElementById("detail-current-price-h3");
+        currentPrice.innerText = Number(data[data.length-1].stck_prpr).toLocaleString('ko-KR') + '원';
+
         // 데이터 정렬
         data.sort((a, b) => (a.stck_bsop_date + a.stck_cntg_hour).localeCompare(b.stck_bsop_date + b.stck_cntg_hour));
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #138 

---

### 📝 작업 내용
- 종목 상세 페이지에서 분/일/주/월/년을 선택하여 차트를 조회할 수있게 하였습니다.
- 종목 상세 페이지의 현재가를 임시로 차트 데이터의 현재가로 설정했습니다.
- 메인 페이지의 디폴트 차트를 종목 리스트 1번 항목의 차트로 나오게 수정하였습니다.
 
---

### 📷 스크린샷 (선택)
분/일/주/월/년 선택 메뉴와 선택 결과
<img width="941" height="315" alt="스크린샷 2026-01-22 112159" src="https://github.com/user-attachments/assets/ae0d27b4-5d6f-45ea-b8ca-ae9f257d846a" />


종목 상세 현재가
<img width="938" height="436" alt="스크린샷 2026-01-22 112322" src="https://github.com/user-attachments/assets/5d0271f9-3b7a-4e56-a0a0-f02166203553" />


메인 디폴트 차트
<img width="1591" height="431" alt="스크린샷 2026-01-22 112314" src="https://github.com/user-attachments/assets/f0e5bc17-6040-4121-bb02-d40750b12339" />

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
