### PR TITLE
Refactor: 검색어 필터링 기능 편의성 향상

### DIFF
--- a/src/main/java/com/antmillion/stock/component/StockCache.java
+++ b/src/main/java/com/antmillion/stock/component/StockCache.java
@@ -33,7 +33,7 @@ public class StockCache {
     //서버에서 필터링하여 결과 전달
     public List<StockDTO> searchStocks(String searchKeyword) {
         return cache.values().stream()
-                .filter(s -> s.getStockName().startsWith(searchKeyword))
+                .filter(s -> s.getStockName().toLowerCase().contains(searchKeyword.toLowerCase()))
                 .sorted(Comparator.comparing(StockDTO::getStockName))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
검색어가 포함된 모든 종목을 검색하고, 영어 대소문자 구분을 없앰

## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #147 
---

### 📝 작업 내용
- 검색 편의성 향상을 위해, 기존에는 검색어로 시작하는 종목들을 밑에 드롭다운으로 보여줬지만, 검색어를 포함하는 모든 종목이 나오도록 변경하였습니다.  ex) 하이닉스 -> SK하이닉스
- 영어 대소문자를 구분하지 않고 검색할 수 있게 변경하였습니다.  ex) sk ->SK하이닉스

---

### 📷 스크린샷 (선택)
검색어 포함
<img width="453" height="86" alt="image" src="https://github.com/user-attachments/assets/4dfb433e-cb96-4c4f-b2f5-0e39c15650cf" />

영어 대소문자
<img width="451" height="310" alt="image" src="https://github.com/user-attachments/assets/867ed5b4-7b52-4fdf-89ac-3951f69d8413" />


---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
