### PR TITLE
Feat: 마이페이지 계좌정보 탭 구현

### DIFF
--- a/src/main/java/com/antmillion/mypage/controller/MyPageController.java
+++ b/src/main/java/com/antmillion/mypage/controller/MyPageController.java
@@ -29,24 +29,7 @@ public class MyPageController {
     public String mainPage() {
         return "mypage/mypage";
     }
-    
-    
-    
-    
-    @GetMapping("/api/realized-profit")
-    @ResponseBody
-    public ResponseEntity<List<Map<String, Object>>> getRealizedProfit(
-            @RequestParam(value = "startDate", required = false) String startDate,
-            @RequestParam(value = "endDate", required = false) String endDate,
-            HttpSession session) {
-        
-        Long accountId = (Long) session.getAttribute("accountId");
-        if (accountId == null) accountId = 1L;
-        
-        // 서비스로 날짜 데이터 전달
-        List<Map<String, Object>> result = myPageService.getRealizedProfit(accountId, startDate, endDate);
-        return ResponseEntity.ok(result);
-    }
+
 
     /**
      * 주식 잔고 데이터를 JSON으로 반환
@@ -68,4 +51,36 @@ public class MyPageController {
         
         return ResponseEntity.ok(holdings);
     }
+    
+    
+    @GetMapping("/api/realized-profit")
+    @ResponseBody
+    public ResponseEntity<List<Map<String, Object>>> getRealizedProfit(
+            @RequestParam(value = "startDate", required = false) String startDate,
+            @RequestParam(value = "endDate", required = false) String endDate,
+            HttpSession session) {
+        
+        Long accountId = (Long) session.getAttribute("accountId");
+        if (accountId == null) accountId = 1L;
+        
+        // 서비스로 날짜 데이터 전달
+        List<Map<String, Object>> result = myPageService.getRealizedProfit(accountId, startDate, endDate);
+        return ResponseEntity.ok(result);
+    }
+    
+    
+    
+    
+    
+    @GetMapping("/api/account-info")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> getAccountInfo(HttpSession session) {
+        Long accountId = (Long) session.getAttribute("accountId");
+        if (accountId == null) accountId = 1L; // 테스트용
+        
+        Map<String, Object> result = myPageService.getAccountInfo(accountId);
+        return ResponseEntity.ok(result);
+    }
+    
+    
 }

--- a/src/main/java/com/antmillion/mypage/mapper/MyPageMapper.java
+++ b/src/main/java/com/antmillion/mypage/mapper/MyPageMapper.java
@@ -11,4 +11,9 @@ public interface MyPageMapper {
     
     // 실현손익 목록 조회 (명칭 통일 및 파라미터 Map으로 변경)
     List<Map<String, Object>> selectRealizedProfit(Map<String, Object> params);
+    
+    
+    
+    // 계좌정보 조회
+    Map<String, Object> selectAccountInfo(Long accountId);
 }

--- a/src/main/java/com/antmillion/mypage/service/MyPageService.java
+++ b/src/main/java/com/antmillion/mypage/service/MyPageService.java
@@ -4,8 +4,16 @@ import java.util.List;
 import java.util.Map;
 
 public interface MyPageService {
+	//1. 주식잔고
     // 계좌 ID를 기반으로 보유 주식 목록(종목명 포함)을 가져옵니다.
     List<Map<String, Object>> getStockHoldings(Long accountId);
     
+    //2. 실현손익
     List<Map<String, Object>> getRealizedProfit(Long accountId, String startDate, String endDate);
+    
+    //3. 체결내역
+    
+
+    //4. 계좌관리
+	Map<String, Object> getAccountInfo(Long accountId);
 }

--- a/src/main/java/com/antmillion/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/com/antmillion/mypage/service/MyPageServiceImpl.java
@@ -15,18 +15,7 @@ public class MyPageServiceImpl implements MyPageService {
 
     private final MyPageMapper myPageMapper;
     
-    @Override
-    public List<Map<String, Object>> getRealizedProfit(Long accountId, String startDate, String endDate) {
-        // 매퍼에 넘길 파라미터 맵 생성 (또는 DTO 사용)
-        Map<String, Object> params = new HashMap<>();
-        params.put("accountId", accountId);
-        params.put("startDate", startDate);
-        params.put("endDate", endDate);
-        
-        return myPageMapper.selectRealizedProfit(params);
-    }
-
-    
+    //1. 주식잔고
     @Override
     public List<Map<String, Object>> getStockHoldings(Long accountId) {
         // 1. DB에서 기본 데이터(수량, 매수금액 등) 가져오기
@@ -57,5 +46,25 @@ public class MyPageServiceImpl implements MyPageService {
         holdings.sort((a, b) -> Long.compare((long)b.get("totalValue"), (long)a.get("totalValue")));
         
         return holdings;
+    }
+    
+    //2. 실현손익
+    @Override
+    public List<Map<String, Object>> getRealizedProfit(Long accountId, String startDate, String endDate) {
+        // 매퍼에 넘길 파라미터 맵 생성 (또는 DTO 사용)
+        Map<String, Object> params = new HashMap<>();
+        params.put("accountId", accountId);
+        params.put("startDate", startDate);
+        params.put("endDate", endDate);
+        
+        return myPageMapper.selectRealizedProfit(params);
+    }
+    
+    
+    
+    //4. 계좌정보
+    @Override
+    public Map<String, Object> getAccountInfo(Long accountId) {
+        return myPageMapper.selectAccountInfo(accountId);
     }
 }

--- a/src/main/resources/mappers/mypage/MyPageMapper.xml
+++ b/src/main/resources/mappers/mypage/MyPageMapper.xml
@@ -42,5 +42,18 @@
 	    
 	    ORDER BY so.updated_at DESC
 	</select>
+	
+    
+
+	<select id="selectAccountInfo" resultType="map">
+	    SELECT 
+	        m.nickname AS "nickname",
+	        a.account_number AS "accountNumber",
+	        a.balance AS "balance",
+	        a.account_created_at AS "createdAt"
+	    FROM account a
+	    JOIN member m ON a.user_id = m.user_id
+	    WHERE a.account_id = #{accountId}
+	</select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/mypage/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/mypage/mypage.jsp
@@ -33,7 +33,7 @@
                         <button class="mypage-tab-button active" data-tab="stock">주식잔고</button>
                         <button class="mypage-tab-button" data-tab="realized">실현손익</button>
                         <button class="mypage-tab-button" data-tab="executed">체결내역</button>
-                        <button class="mypage-tab-button" data-tab="trading">매매내역</button>
+                        <button class="mypage-tab-button" data-tab="account">계좌정보</button>
                     </div>
 
                     <!-- 탭 콘텐츠 -->
@@ -137,41 +137,34 @@
                             </div>
                         </div>
 
-                        <!-- 매매내역 탭 -->
-                        <div class="mypage-tab-panel" id="trading-panel">
-                            <h2 class="mypage-section-title">매매내역</h2>
-
-                            <!-- 기간 선택 -->
-                            <div class="mypage-date-filter">
-                                <label class="mypage-date-label">기간</label>
-                                <div class="mypage-date-inputs">
-                                    <div class="mypage-date-input-wrapper">
-                                        <input type="date" class="mypage-date-input"
-                                            id="tradingStartDate" value="2026-01-15">
-                                        <button class="mypage-date-clear"
-                                            data-target="tradingStartDate">×</button>
-                                    </div>
-                                    <span class="mypage-date-separator">~</span>
-                                    <div class="mypage-date-input-wrapper">
-                                        <input type="date" class="mypage-date-input"
-                                            id="tradingEndDate" value="2026-01-15">
-                                        <button class="mypage-date-clear" data-target="tradingEndDate">×</button>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- 필터 버튼 -->
-                            <div class="mypage-filter-menu">
-                                <button class="mypage-filter-button active" data-filter="all">전체</button>
-                                <button class="mypage-filter-button" data-filter="buy">매수</button>
-                                <button class="mypage-filter-button" data-filter="sell">매도</button>
-                            </div>
-
-                            <!-- 매매내역 목록 -->
-                            <div class="mypage-trading-list" id="tradingList">
-                                <!-- JavaScript로 동적 생성 -->
-                            </div>
-                        </div>
+                        <!-- 계좌정보 탭 -->
+                        <div class="mypage-tab-panel" id="account-panel">
+						    <h2 class="mypage-section-title">계좌정보</h2>
+						
+						    <div class="account-card" style="margin-top: 20px;">
+						        <h3 class="account-user-title" style="border-bottom: 1px solid #ddd; padding-bottom: 10px; margin-bottom: 15px;">
+						            <!-- <span id="userNickname" class="negative" style="font-weight: bold;">로딩 중...</span>님의 계좌  -->
+						            <span id="userNickname" style="color: #2271e9; font-weight: 800; margin-right: 2px;">(로딩 중)</span><span style="font-size: 0.99em; color: #333;">님의 계좌</span>
+						        </h3>
+						        
+						        <div class="account-info-list" style="line-height: 2;">
+						            <div class="account-detail-row">
+						                <span class="label" style="width: 100px; display: inline-block; color: #666;">계좌번호</span>
+						                <span class="value" id="accNumber" style="font-weight: 500;">-</span>
+						            </div>
+						            <div class="account-detail-row">
+						                <span class="label" style="width: 100px; display: inline-block; color: #666;">잔고</span>
+						                <span class="value accent" style="font-weight: bold;"><span id="accBalance">0</span>원</span>
+						            </div>
+						            <div class="account-detail-row">
+						                <span class="label" style="width: 100px; display: inline-block; color: #666;">개설일</span>
+						                <span class="value" id="accCreateDate" style="color: #666;">-</span>
+						            </div>
+						        </div>
+						    </div>
+						</div>
+						
+						
                     </div>
                 </div>
 

--- a/src/main/webapp/resources/js/mypage/mypage.js
+++ b/src/main/webapp/resources/js/mypage/mypage.js
@@ -308,6 +308,8 @@ function setupEventListeners() {
                 loadStockHoldings();
             } else if (target === 'realized') {
                 loadRealizedProfit(); 
+            } else if (target === 'account') { // 👈 계좌정보 탭 추가
+                loadAccountInfo();
             }
         });
     });
@@ -647,39 +649,41 @@ function renderExecutedOrders(filter) {
     }).join('');
 }
 
-// ===========================
-// 매매내역 렌더링
-// ===========================
-function renderTradingHistory(filter) {
-    if (!tradingList) return;
-    
-    let history = sampleData.tradingHistory;
-    
-    // 필터 적용
-    if (filter === 'buy') {
-        history = history.filter(item => item.type === 'buy');
-    } else if (filter === 'sell') {
-        history = history.filter(item => item.type === 'sell');
-    }
-    
-    tradingList.innerHTML = history.map(item => {
-        const typeClass = item.type === 'buy' ? 'mypage-buy-badge' : 'mypage-sell-badge';
-        const typeText = item.type === 'buy' ? '매수' : '매도';
-        
-        return `
-            <div class="mypage-trading-item">
-                <div class="mypage-trading-date">${item.date}</div>
-                <div class="mypage-trading-stock-info">
-                    <div>
-                        <span class="mypage-trading-stock-name">${item.stock}</span>
-                        <span class="${typeClass}">${typeText} ${item.shares}주</span>
-                    </div>
-                    <div class="mypage-trading-amount">${item.amount.toLocaleString()}원</div>
-                </div>
-                <div class="mypage-trading-detail">${item.detail}</div>
-            </div>
-        `;
-    }).join('');
+/**
+ * 계좌 정보 데이터를 서버에서 가져와 화면에 렌더링
+ */
+/**
+ * 계좌 정보 데이터를 서버에서 가져와 화면에 렌더링
+ */
+function loadAccountInfo() {
+    fetch(`${contextPath}/mypage/api/account-info`)
+        .then(response => {
+            if (!response.ok) throw new Error("계좌 정보 로드 실패");
+            return response.json();
+        })
+        .then(data => {
+            if (data) {
+                document.getElementById("userNickname").innerText = data.nickname;
+                document.getElementById("accNumber").innerText = data.accountNumber || "정보 없음";
+                document.getElementById("accBalance").innerText = formatNumber(data.balance || 0);
+                
+                // ✅ 날짜 처리 로직 개선
+                const createDateEl = document.getElementById("accCreateDate");
+                if (data.createdAt) {
+                    // 서버 데이터가 [2026, 1, 22] 배열 형식이거나 문자열인 경우 모두 대응
+                    const date = Array.isArray(data.createdAt) 
+                        ? new Date(data.createdAt[0], data.createdAt[1] - 1, data.createdAt[2])
+                        : new Date(data.createdAt);
+
+                    if (!isNaN(date.getTime())) {
+                        createDateEl.innerText = date.toLocaleDateString('ko-KR');
+                    } else {
+                        createDateEl.innerText = data.createdAt; // 변환 실패 시 원본 표시
+                    }
+                }
+            }
+        })
+        .catch(error => console.error("Error:", error));
 }
 
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #152 

---

### 📝 작업 내용
- 마이페이지 계좌정보 탭을 DB와 연동하여 동적으로 구현했습니다.
- 매매내역 관련 코드를 삭제하고 계좌정보 관련 코드로 대체했습니다.


---

### 📷 스크린샷 (선택)
- 
<img width="1883" height="890" alt="image" src="https://github.com/user-attachments/assets/36d7225d-07d8-47fb-a085-3dd926cf7df8" />



---

### 💬 리뷰 요구사항 (선택)
- account에 account_created_at 칼럼 추가해주세요


--------------------------------------------------------------------------------------------------
ALTER TABLE account ADD COLUMN account_created_at DATETIME NULL;
--------------------------------------------------------------------------------------------------
create table account
(
    account_id      bigint auto_increment primary key,
    user_id         bigint      not null,
    account_number varchar(50) null,
    balance         bigint      null,
    account_created_at datetime    null,
    constraint fk_account_user foreign key (user_id) references member (user_id)
) charset = utf8mb4;
---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
