### PR TITLE
Feat: 손실회피(Loss Aversion) 매매 편향 경고 기능 구현

### DIFF
--- a/src/main/java/com/antmillion/history/controller/BiasAlertController.java
+++ b/src/main/java/com/antmillion/history/controller/BiasAlertController.java
@@ -47,5 +47,27 @@ public class BiasAlertController {
         System.out.println("결과: " + result);
         return ResponseEntity.ok(result);
     }
+    
+    /**
+     * 손실회피 편향 체크
+     * 조건: 수익률 -7% 이하 && 최근 5거래일간 매도 이력 없음
+     */
+    @GetMapping("/check-loss-aversion")
+    public ResponseEntity<BiasAlertDTO> checkLossAversion(
+            @RequestParam(required = false, defaultValue = "1") Long accountId,
+            @RequestParam(required = false, defaultValue = "1") Long userId,
+            @RequestParam String stockCode) {
 
+        System.out.println("BiasAlertController: 손실회피 체크 - accountId=" + accountId + ", userId=" + userId + ", stockCode=" + stockCode);
+
+        BiasAlertDTO result = biasAlertService.checkLossAversionBias(accountId, stockCode, userId);
+
+        if (result == null) {
+            System.out.println("결과: 보유하지 않은 종목 (204 No Content)");
+            return ResponseEntity.noContent().build();
+        }
+
+        System.out.println("결과: " + result);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/src/main/java/com/antmillion/history/mapper/BiasAlertMapper.java
+++ b/src/main/java/com/antmillion/history/mapper/BiasAlertMapper.java
@@ -28,4 +28,15 @@ public interface BiasAlertMapper {
      * @return 현재가
      */
     BigDecimal selectCurrentPrice(@Param("stockCode") String stockCode);
+    
+    /**
+     * 최근 5거래일간 매도 이력 체크 (손실회피 편향용)
+     * @param userId 사용자 ID
+     * @param stockCode 종목 코드
+     * @return 최근 5일 내 매도 이력 있으면 true
+     */
+    boolean checkRecentSellHistory(
+        @Param("userId") Long userId,
+        @Param("stockCode") String stockCode
+    );
 }

--- a/src/main/java/com/antmillion/history/service/BiasAlertService.java
+++ b/src/main/java/com/antmillion/history/service/BiasAlertService.java
@@ -28,6 +28,9 @@ public class BiasAlertService {
     // 위험회피 편향 기준
     private static final BigDecimal RISK_AVERSION_PROFIT_THRESHOLD = new BigDecimal("3.0");
     private static final int RISK_AVERSION_HOLDING_DAYS = 3;
+    
+    // 손실회피 편향 기준
+    private static final BigDecimal LOSS_AVERSION_LOSS_THRESHOLD = new BigDecimal("-7.0");
 
     /**
      * 위험회피 편향 체크
@@ -73,6 +76,60 @@ public class BiasAlertService {
                 .build();
 
         //핵심: 경고가 뜨는 순간 자동 저장
+        if (hasAlert) {
+            saveBiasAlert(result);
+        }
+
+        return result;
+    }
+
+    /**
+     * 손실회피 편향 체크
+     * 조건: 수익률 -7% 이하 && 최근 5거래일간 매도 이력 없음
+     */
+    public BiasAlertDTO checkLossAversionBias(Long accountId, String stockCode, Long userId) {
+        log.info("손실회피 체크 시작 - accountId={}, stockCode={}, userId={}", accountId, stockCode, userId);
+
+        // 1. 보유 자산 조회
+        BiasAlertDTO asset = biasAlertMapper.selectAssetForBiasCheck(accountId, stockCode);
+
+        if (asset == null) {
+            log.info("보유하지 않은 종목 - stockCode={}", stockCode);
+            return null;
+        }
+
+        // 2. 현재가 조회
+        BigDecimal currentPrice = biasAlertMapper.selectCurrentPrice(stockCode);
+
+        // 3. 수익률 계산
+        BigDecimal profitRate = calculateProfitRate(asset.getAvgPrice(), currentPrice);
+
+        // 4. 최근 5거래일 매도 이력 체크
+        boolean hasRecentSell = biasAlertMapper.checkRecentSellHistory(userId, stockCode);
+
+        // 5. 편향 조건 체크: 수익률 -7% 이하 && 최근 5거래일 매도 이력 없음
+        boolean hasAlert = profitRate.compareTo(LOSS_AVERSION_LOSS_THRESHOLD) <= 0
+                && !hasRecentSell;
+
+        log.info("손실회피 체크 결과 - 수익률: {}%, 최근매도이력: {}, 경고: {}",
+                profitRate, hasRecentSell, hasAlert);
+
+        // 6. 결과 DTO 만들기
+        BiasAlertDTO result = BiasAlertDTO.builder()
+                .userId(userId)
+                .stockCode(asset.getStockCode())
+                .stockName(asset.getStockName())
+                .quantity(asset.getQuantity())
+                .avgPrice(asset.getAvgPrice())
+                .currentPrice(currentPrice)
+                .profitRate(profitRate)
+                .purchaseDate(asset.getPurchaseDate())
+                .holdingDays(asset.getHoldingDays())
+                .biasType(BiasType.LOSS_AVERSION)
+                .hasAlert(hasAlert)
+                .build();
+
+        // 7. 경고가 뜨는 순간 자동 저장
         if (hasAlert) {
             saveBiasAlert(result);
         }
@@ -131,7 +188,7 @@ public class BiasAlertService {
      */
     private String getBiasTypeString(BiasType biasType) {
         if (biasType == null) return "UNKNOWN";
-        return biasType.getCode(); // RISK_AVERSION / LOSS_AVERSION ...
+        return biasType.getCode(); 
     }
 
     /**

--- a/src/main/resources/mappers/history/BiasAlertMapper.xml
+++ b/src/main/resources/mappers/history/BiasAlertMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.antmillion.history.mapper.BiasAlertMapper">
 
-    <!-- ⭐ ResultMap 추가 -->
+    <!--ResultMap 추가 -->
     <resultMap id="BiasAlertResultMap" type="com.antmillion.history.dto.BiasAlertDTO">
         <result property="stockCode" column="stockCode"/>
         <result property="stockName" column="stockName"/>
@@ -34,10 +34,25 @@
         SELECT 
             CASE 
                 WHEN #{stockCode} = '005930' THEN 72100.00
-                WHEN #{stockCode} = '000660' THEN 51000.00
-                WHEN #{stockCode} = '035720' THEN 185000.00
+                WHEN #{stockCode} = '000660' THEN 47430.00
                 ELSE 50000.00
             END AS currentPrice
     </select>
+    
+    <!-- 최근 5거래일간 매도 이력 체크 (손실회피용) -->
+    <select id="checkRecentSellHistory" resultType="boolean">
+        SELECT 
+            CASE 
+                WHEN COUNT(*) > 0 THEN TRUE 
+                ELSE FALSE 
+            END
+        FROM stock_order
+        WHERE account_id = (SELECT account_id FROM account WHERE user_id = #{userId} LIMIT 1)
+          AND stock_code = #{stockCode}
+          AND transaction_type = 'SELL'
+          AND status = 'COMPLETED'
+          AND created_at >= DATE_SUB(NOW(), INTERVAL 5 DAY)
+    </select>
 
+    
 </mapper>

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -25,7 +25,7 @@
     <!-- ⭐ 매매 편향 경고 뱃지 -->
     <div class="bias-alert-badge" id="biasAlertBadge" style="display:none;">
         <span class="bias-alert-icon">⚠️</span>
-        <span class="bias-alert-text">위험회피 주의 경고</span>
+        <span class="bias-alert-text">위험회피 주의</span>
     </div>
 
     <div class="header-user-info">
@@ -272,10 +272,10 @@ function showBiasAlert(biasType = 'RISK_AVERSION') {
         
         // 편향 타입에 따라 텍스트 및 색상 변경
         if (biasType === 'LOSS_AVERSION') {
-            textSpan.textContent = '손실회피 주의 경고';
+            textSpan.textContent = '손실회피 주의';
             badge.classList.remove('risk-aversion');  // 초록색 제거
         } else {
-            textSpan.textContent = '위험회피 주의 경고';
+            textSpan.textContent = '위험회피 주의';
             badge.classList.add('risk-aversion');  // 초록색 추가
         }
         

--- a/src/main/webapp/WEB-INF/views/common/header.jsp
+++ b/src/main/webapp/WEB-INF/views/common/header.jsp
@@ -265,12 +265,22 @@ function closeProfile() {
     document.getElementById('profileModal').classList.remove('show');
 }
 
-function showBiasAlert() {
+function showBiasAlert(biasType = 'RISK_AVERSION') {
     const badge = document.getElementById('biasAlertBadge');
     if (badge) {
+        const textSpan = badge.querySelector('.bias-alert-text');
+        
+        // 편향 타입에 따라 텍스트 및 색상 변경
+        if (biasType === 'LOSS_AVERSION') {
+            textSpan.textContent = '손실회피 주의 경고';
+            badge.classList.remove('risk-aversion');  // 초록색 제거
+        } else {
+            textSpan.textContent = '위험회피 주의 경고';
+            badge.classList.add('risk-aversion');  // 초록색 추가
+        }
+        
         badge.style.display = 'flex';
-        sessionStorage.setItem('riskAversionBias', 'true'); 
-        console.log('위험회피 경고 표시');
+        console.log(biasType + ' 경고 표시');
     }
 }
 
@@ -278,13 +288,12 @@ function hideBiasAlert() {
     const badge = document.getElementById('biasAlertBadge');
     if (badge) {
         badge.style.display = 'none';
-        sessionStorage.removeItem('riskAversionBias'); 
-        console.log('위험회피 경고 제거');
+        console.log('경고 제거');
     }
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-    // 빨간 점 복원
+    // 빨간 점만 복원 (알림창 열어야 꺼짐)
     const hasUnreadAlert = sessionStorage.getItem('hasUnreadAlert');
     if (hasUnreadAlert === 'true') {
         const notifBtn = document.querySelector('.header-notification-btn');
@@ -292,11 +301,8 @@ document.addEventListener('DOMContentLoaded', function () {
         console.log('[초기 로드] 세션 기반 빨간 점 복원');
     }
     
-    const hasBias = sessionStorage.getItem('riskAversionBias');
-    if (hasBias === 'true') {
-        showBiasAlert();
-        console.log('[초기 로드] 세션 기반 위험회피 경고 복원');
-    }
+    // 경고 배지는 복원하지 않음 (페이지마다 새로 체크)
+    console.log('[초기 로드] 경고 배지는 각 페이지에서 체크');
 
     const userProfile = document.getElementById('userProfile');
     const profileModal = document.getElementById('profileModal');
@@ -327,12 +333,14 @@ document.addEventListener('DOMContentLoaded', function () {
 // 뒤로가기/앞으로가기 대응
 window.addEventListener('pageshow', function(event) {
     console.log('[pageshow] 이벤트 발생, bfcache:', event.persisted);
-    const hasBias = sessionStorage.getItem('riskAversionBias');
-    if (hasBias === 'true') {
-        const badge = document.getElementById('biasAlertBadge');
-        if (badge && badge.style.display !== 'flex') {
-            showBiasAlert();
-            console.log('[뒤로가기] 세션 기반 위험회피 경고 복원');
+    
+    // 빨간 점만 복원 (경고 배지는 복원 안 함)
+    const hasUnreadAlert = sessionStorage.getItem('hasUnreadAlert');
+    if (hasUnreadAlert === 'true') {
+        const notifBtn = document.querySelector('.header-notification-btn');
+        if (notifBtn && !notifBtn.classList.contains('has-unread')) {
+            notifBtn.classList.add('has-unread');
+            console.log('[뒤로가기] 빨간 점 복원');
         }
     }
 });

--- a/src/main/webapp/resources/css/common/header.css
+++ b/src/main/webapp/resources/css/common/header.css
@@ -598,7 +598,7 @@ to {
     align-items: center;
     gap: 10px;
     padding: 10px 18px;
-    background: linear-gradient(135deg, #ff9f43 0%, #ff6a3d 100%);
+    background: linear-gradient(135deg, #ff9f43 0%, #ff6a3d 100%); 
     border-radius: 18px;
     cursor: pointer;
     transition: all 0.3s ease;
@@ -608,6 +608,25 @@ to {
     animation: biasAlertSlideIn 0.5s ease;
     margin-left: auto;
     margin-right: 12px;
+}
+
+/* 위험회피 - 초록색 */
+.bias-alert-badge.risk-aversion {
+    background: linear-gradient(135deg, #56ab2f 0%, #a8e063 100%);
+    box-shadow: 0 4px 15px rgba(86, 171, 47, 0.45);
+}
+
+.bias-alert-badge.risk-aversion::after {
+    border-left-color: #a8e063;
+}
+
+.bias-alert-badge.risk-aversion:hover {
+    background: linear-gradient(135deg, #4a9428 0%, #95d64f 100%);
+    box-shadow: 0 6px 20px rgba(86, 171, 47, 0.6);
+}
+
+.bias-alert-badge.risk-aversion:hover::after {
+    border-left-color: #95d64f;
 }
 
 /* 말풍선 꼬리 */

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -35,6 +35,36 @@ async function checkBiasAlert(stockCode) {
     }
 }
 
+// 손실회피 체크 함수
+async function checkLossAversionAlert(stockCode) {
+    console.log('[손실회피 API 호출] stockCode:', stockCode);
+    
+    try {
+        const url = contextPath + '/api/bias-alert/check-loss-aversion?stockCode=' + stockCode;
+        console.log('[손실회피 API URL]', url);
+        
+        const response = await fetch(url);
+        console.log('[손실회피 API 응답 상태]', response.status);
+        
+        if (response.status === 204) {
+            console.log('[결과] 보유하지 않은 종목');
+            return null;
+        }
+        
+        if (!response.ok) {
+            throw new Error('손실회피 API 호출 실패: ' + response.status);
+        }
+        
+        const data = await response.json();
+        console.log('[손실회피 API 결과]', data);
+        return data;
+        
+    } catch (error) {
+        console.error('[손실회피 API 에러]', error);
+        return null;
+    }
+}
+
 // 일별 분봉 조회 - 차트
 let stockChart = null;
 let candleSeries = null;
@@ -267,9 +297,32 @@ window.addEventListener('resize', () => {
 });
 
 // ===== DOM 로드 후 실행 =====
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', async function() {
     checkFavoriteStatus();
     console.log('=== 매매 편향 체크 시스템 로드 완료 (API 연동) ===');
+    
+    // ===== 페이지 진입 시 손실회피 체크 (상시) =====
+    const urlParams = new URLSearchParams(window.location.search);
+    const stockCode = urlParams.get('code');
+    
+    if (stockCode) {
+        console.log('[페이지 로드] 손실회피 체크 시작 - stockCode:', stockCode);
+        const lossData = await checkLossAversionAlert(stockCode);
+        
+        if (lossData && lossData.hasAlert) {
+            console.log('[페이지 로드] 손실회피 경고 발생: ' + lossData.stockName + ' ' + lossData.profitRate + '% 손실 중');
+            
+            if (typeof showBiasAlert === 'function') {
+                showBiasAlert('LOSS_AVERSION');
+                
+                if (typeof checkUnreadAlerts === 'function') {
+                    setTimeout(() => { checkUnreadAlerts(); }, 0);
+                }
+            }
+        } else {
+            console.log('[페이지 로드] 손실회피 조건 미달');
+        }
+    }
     
     // 탭 요소 확인
     const tabs = document.querySelectorAll('.detail-tab, .detail-tab-active');
@@ -327,8 +380,8 @@ document.addEventListener('DOMContentLoaded', function() {
                 buyBar.style.width = '78%';
                 sellBar.style.width = '22%';
                 
-                // 매수 탭에서는 경고를 유지 (숨기지 않음)
-                console.log('[경고] 매수 탭 - 경고 유지');
+                // 매수 탭에서는 경고 체크 안 함
+                console.log('[경고] 매수 탭 - 경고 체크 없음');
                    
             } else if (type === 'sell') {
                 console.log('[UI 변경] 매도 모드');
@@ -346,37 +399,31 @@ document.addEventListener('DOMContentLoaded', function() {
                 buyBar.style.width = '22%';
                 sellBar.style.width = '78%';
                 
-                // 매도 탭 클릭 시 API로 안전선호 체크
+                // 매도 탭 클릭 시 위험회피 체크
                 const urlParams = new URLSearchParams(window.location.search);
                 const stockCode = urlParams.get('code');
                 console.log('[종목 코드]', stockCode);
                 
                 if (stockCode) {
-                    const biasData = await checkBiasAlert(stockCode);
+                    const riskData = await checkBiasAlert(stockCode);
                     
-                    if (biasData && biasData.hasAlert) {
-                        console.log('안전선호 경고: ' + biasData.stockName + ' +' + biasData.profitRate + '% 수익 중 (' + biasData.holdingDays + '일 보유)');
+                    if (riskData && riskData.hasAlert) {
+                        console.log('위험회피 경고: ' + riskData.stockName + ' +' + riskData.profitRate + '% 수익 중 (' + riskData.holdingDays + '일 보유)');
                         
-                        // 헤더에 경고 표시
                         if (typeof showBiasAlert === 'function') {
-                            showBiasAlert();
+                            showBiasAlert('RISK_AVERSION');
                             
-                            // 빨간 점도 켜기 (DB 저장 후 체크하도록 딜레이)
                             if (typeof checkUnreadAlerts === 'function') {
                                 setTimeout(() => { checkUnreadAlerts(); }, 0);
                             }
-                        } else {
-                            console.error('showBiasAlert 함수 없음!');
                         }
                     } else {
-                        if (biasData) {
-                            console.log('편향 없음 - 수익률: ' + biasData.profitRate + '%, 보유일수: ' + biasData.holdingDays + '일');
+                        // 위험회피 조건 미달
+                        if (riskData) {
+                            console.log('위험회피 조건 미달 - 수익률: ' + riskData.profitRate + '%, 보유일수: ' + riskData.holdingDays + '일');
                         }
-                        
-                        // 경고 조건 미달 시에만 숨김
-                        if (typeof hideBiasAlert === 'function') {
-                            hideBiasAlert();
-                        }
+                        // 손실회피 경고는 유지하므로 hideBiasAlert() 호출 안 함
+                        console.log('[경고] 기존 경고 유지 (손실회피 경고가 있을 수 있음)');
                     }
                 } else {
                     console.warn('URL에 종목 코드(code) 없음');


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #150 

---

### 📝 작업 내용
종목 상세 페이지에서 손실 상태임에도 매도를 미루는 손실회피 성향을 감지해 사용자에게 사전 경고를 제공하는 기능을 추가했습니다.
손실회피 조건 충족 시 경고 UI를 노출하고, 알림(History)은 시간 기준으로 중복 저장을 방지하도록 구현했습니다.
구현 내용
최근 5거래일 매도 이력 조회 쿼리 추가, 손실회피 판단 로직 구현, 조건 충족 시 알림 자동 저장
헤더 경고 배지 색상 구분, 종목 상세 페이지 진입 시 손실회피 자동 체크, 위험회피 조건 미달 시에도 손실회피 경고는 유지
경고 배지: 해당 페이지에서만 표시 (페이지 이동 시 제거), UI 표시 여부와 DB 저장 로직 분리

### 📷 스크린샷 (선택)
![알림1](https://github.com/user-attachments/assets/0346eb95-fbf8-4f9d-b56b-a9dc93073813)
![알림2](https://github.com/user-attachments/assets/1eb20560-93ad-4911-9efd-f66b485b1c3c)
![알림3](https://github.com/user-attachments/assets/fd8ae942-96aa-406e-887e-b6cb54a0822b)
![마이페이지](https://github.com/user-attachments/assets/78a15e5f-5e2d-4873-829f-564f6780a8bd)

### 💬 리뷰 요구사항 (선택)
-- 테스트 데이터
INSERT INTO asset (account_id, stock_code, quantity, updated_at, purchase_amount, avg_price)
VALUES (1, '000660', 100, DATE_SUB(NOW(), INTERVAL 5 DAY), 5100000, 51000.00)
ON DUPLICATE KEY UPDATE
    quantity = 100,
    updated_at = DATE_SUB(NOW(), INTERVAL 5 DAY),
    purchase_amount = 5100000,
    avg_price = 51000.00;

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
