### PR TITLE
Feat: 메인 페이지, 종목리스트에 실시간 현재가 적용

### DIFF
--- a/src/main/java/com/antmillion/kis/config/WebSocketBufferConfig.java
+++ b/src/main/java/com/antmillion/kis/config/WebSocketBufferConfig.java
@@ -1,0 +1,22 @@
+package com.antmillion.kis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
+
+@Configuration
+public class WebSocketBufferConfig {
+
+    @Bean
+    public ServletServerContainerFactoryBean createWebSocketContainer() {
+        ServletServerContainerFactoryBean container =
+                new ServletServerContainerFactoryBean();
+
+        // KIS 데이터는 꽤 큼 → 5MB 이상 권장
+        container.setMaxTextMessageBufferSize(5 * 1024 * 1024);
+        container.setMaxBinaryMessageBufferSize(5 * 1024 * 1024);
+
+        return container;
+    }
+
+}

--- a/src/main/java/com/antmillion/kis/controller/KisController.java
+++ b/src/main/java/com/antmillion/kis/controller/KisController.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
-//@RestController 
-@Controller // 테스트를 위해서 @Controller 활성화 했습니다.
+@RestController
+//@Controller // 테스트를 위해서 @Controller 활성화 했습니다.
 @RequestMapping("/api/kis")
 public class KisController {
 

--- a/src/main/java/com/antmillion/kis/controller/KisWebSocketController.java
+++ b/src/main/java/com/antmillion/kis/controller/KisWebSocketController.java
@@ -28,7 +28,7 @@ public class KisWebSocketController {
         try {
             kisWebSocketManager.subscribe(stockCode, trId);
             Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
+            if (trId.equals("H0STCNT0")) {
                 stocks = kisWebSocketManager.getPresentSubscribedStocks();
             } else {
                 stocks = kisWebSocketManager.getAskBidSubscribedStocks();
@@ -59,7 +59,7 @@ public class KisWebSocketController {
                 kisWebSocketManager.subscribe(stockCode, trId);
             }
             Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
+            if (trId.equals("H0STCNT0")) {
                 stocks = kisWebSocketManager.getPresentSubscribedStocks();
             } else {
                 stocks = kisWebSocketManager.getAskBidSubscribedStocks();
@@ -87,7 +87,7 @@ public class KisWebSocketController {
         try {
             kisWebSocketManager.unsubscribe(stockCode, trId);
             Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
+            if (trId.equals("H0STCNT0")) {
                 stocks = kisWebSocketManager.getPresentSubscribedStocks();
             } else {
                 stocks = kisWebSocketManager.getAskBidSubscribedStocks();
@@ -112,7 +112,7 @@ public class KisWebSocketController {
         try {
             kisWebSocketManager.unsubscribeAll(trId);
             Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
+            if (trId.equals("H0STCNT0")) {
                 stocks = kisWebSocketManager.getPresentSubscribedStocks();
             } else {
                 stocks = kisWebSocketManager.getAskBidSubscribedStocks();
@@ -136,7 +136,7 @@ public class KisWebSocketController {
             @RequestParam("trId") String trId
     ) {
         Map<String, Object> response = new HashMap<>();
-        Set<String> subscribed = trId.equals("H0UNCNT0") ?
+        Set<String> subscribed = trId.equals("H0STCNT0") ?
                 kisWebSocketManager.getPresentSubscribedStocks()
                 : kisWebSocketManager.getAskBidSubscribedStocks();
         response.put("count", subscribed.size());

--- a/src/main/java/com/antmillion/kis/controller/MockDataController.java
+++ b/src/main/java/com/antmillion/kis/controller/MockDataController.java
@@ -1,0 +1,108 @@
+package com.antmillion.kis.controller;
+
+import com.antmillion.kis.service.MockDataService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/kis/mock")
+@RequiredArgsConstructor
+public class MockDataController {
+    private final MockDataService mockDataService;
+
+    /**
+     * Mock 종목 일괄 추가
+     * POST /api/kis/mock/add-stocks
+     * Body: [{"stockCode": "005930", "basePrice": 75000}, ...]
+     */
+    @PostMapping("/add-stocks")
+    public Map<String, Object> addMockStocks(@RequestBody List<Map<String, Object>> stocks) {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            for (Map<String, Object> stock : stocks) {
+                String stockCode = (String) stock.get("stockCode");
+                int basePrice = (int) stock.get("basePrice");
+                mockDataService.addMockStock(stockCode, basePrice);
+            }
+            response.put("success", true);
+            response.put("message", "Mock 종목 추가 완료");
+            response.put("count", mockDataService.getMockStockCount());
+        } catch (Exception e) {
+            response.put("success", false);
+            response.put("message", "Mock 종목 추가 실패: " + e.getMessage());
+        }
+        return response;
+    }
+
+    /**
+     * Mock 데이터 전송 시작
+     * POST /api/kis/mock/start
+     */
+    @PostMapping("/start")
+    public Map<String, Object> startMockData() {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            mockDataService.startMockData();
+            response.put("success", true);
+            response.put("message", "Mock 데이터 전송 시작");
+            response.put("isRunning", mockDataService.isRunning());
+        } catch (Exception e) {
+            response.put("success", false);
+            response.put("message", "Mock 데이터 시작 실패: " + e.getMessage());
+        }
+        return response;
+    }
+
+    /**
+     * Mock 데이터 전송 중지
+     * POST /api/kis/mock/stop
+     */
+    @PostMapping("/stop")
+    public Map<String, Object> stopMockData() {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            mockDataService.stopMockData();
+            response.put("success", true);
+            response.put("message", "Mock 데이터 전송 중지");
+            response.put("isRunning", mockDataService.isRunning());
+        } catch (Exception e) {
+            response.put("success", false);
+            response.put("message", "Mock 데이터 중지 실패: " + e.getMessage());
+        }
+        return response;
+    }
+
+    /**
+     * Mock 데이터 상태 확인
+     * GET /api/kis/mock/status
+     */
+    @GetMapping("/status")
+    public Map<String, Object> getMockStatus() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("isRunning", mockDataService.isRunning());
+        response.put("stockCount", mockDataService.getMockStockCount());
+        return response;
+    }
+
+    /**
+     * 모든 Mock 종목 제거
+     * POST /api/kis/mock/clear
+     */
+    @PostMapping("/clear")
+    public Map<String, Object> clearMockStocks() {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            mockDataService.clearAllMockStocks();
+            response.put("success", true);
+            response.put("message", "모든 Mock 종목 제거 완료");
+        } catch (Exception e) {
+            response.put("success", false);
+            response.put("message", "Mock 종목 제거 실패: " + e.getMessage());
+        }
+        return response;
+    }
+}

--- a/src/main/java/com/antmillion/kis/dto/KisWebSocketTransactionPriceResponse.java
+++ b/src/main/java/com/antmillion/kis/dto/KisWebSocketTransactionPriceResponse.java
@@ -10,6 +10,8 @@ public class KisWebSocketTransactionPriceResponse {
     private String mkscShrnIscd; // 유가증권 단축 종목코드
 	@JsonProperty("STCK_PRPR")
     private Integer stckPrpr; // 주식 현재가
+	@JsonProperty("PRDY_VRSS_SIGN")
+	private String prdySign; // 전일 대비 부호 (+,-)
 	@JsonProperty("PRDY_VRSS")
 	private Integer prdyVrss; // 전일 대비
 	@JsonProperty("PRDY_CTRT")

--- a/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
+++ b/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
@@ -75,6 +75,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
                 Map<String, String> tradeData = new HashMap<>();
                 tradeData.put("mkscShrnIscd", data[0]); // 종목코드
                 tradeData.put("stckPrpr", data[2]);     // 현재가
+                tradeData.put("prdySign", data[3]); // 전일 대비 부호
                 tradeData.put("prdyVrss", data[4]);	// 전일 대비
                 tradeData.put("prdyCtrt", data[5]);     // 대비율
                 tradeData.put("shnuRate", data[22]);     // 매수 비율

--- a/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
+++ b/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
@@ -69,7 +69,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         // 3. 실시간 실무 데이터 처리 (문자열 파싱)
         try {
             String[] parts = payload.split("\\|");
-            if ("H0UNCNT0".equals(parts[1])) {
+            if ("H0STCNT0".equals(parts[1])) {
             	String[] data = parts[3].split("\\^");
             	// [0], [2], [4], [5], [22]
                 Map<String, String> tradeData = new HashMap<>();
@@ -84,7 +84,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
                 // STOMP 전송
                 messagingTemplate.convertAndSend("/topic/kis-trade/present" + stockCode, tradeData); // 실시간 체결가
                 System.out.println("체결가 수신: " + tradeData);
-            } else if ("H0UNASP0".equals(parts[1])) {
+            } else if ("H0STASP0".equals(parts[1])) {
                 String[] data = parts[3].split("\\^");
                 Map<String, String> askBidData = new HashMap<>();
                 askBidData.put("mkscShrnIscd", data[0]); // 종목코드

--- a/src/main/java/com/antmillion/kis/manager/KisWebSocketManager.java
+++ b/src/main/java/com/antmillion/kis/manager/KisWebSocketManager.java
@@ -101,7 +101,7 @@ public class KisWebSocketManager {
     // 세션 관리용
     public synchronized void subscribe(String stockCode, String trId) {
         // 중복 구독 방지
-        if (trId.equals("H0UNCNT0")) {
+        if (trId.equals("H0STCNT0")) {
             if (presentSubscribedStocks.contains(stockCode)) {
                 System.out.println("이미 체결가 구독 중인 종목: " + stockCode);
                 return;
@@ -121,7 +121,7 @@ public class KisWebSocketManager {
         
         this.sendSubscribeMessage(this.session, stockCode, "1", trId);  // 실제 구독 메시지 전송
 
-        if (trId.equals("H0UNCNT0")) {
+        if (trId.equals("H0STCNT0")) {
             presentSubscribedStocks.add(stockCode);
         } else {
             askBidSubscribedStocks.add(stockCode);
@@ -132,7 +132,7 @@ public class KisWebSocketManager {
 
     // 🆕 구독 해제 메소드
     public synchronized void unsubscribe(String stockCode, String trId) {
-        if (trId.equals("H0UNCNT0")) {
+        if (trId.equals("H0STCNT0")) {
             if (!presentSubscribedStocks.contains(stockCode)) {
                 System.out.println("체결가 구독 중이 아닌 종목: " + stockCode);
                 return;
@@ -146,7 +146,7 @@ public class KisWebSocketManager {
 
         if (this.session != null && this.session.isOpen()) {
             sendSubscribeMessage(this.session, stockCode, "2", trId);  // "2" = 구독 해제
-            if (trId.equals("H0UNCNT0")) {
+            if (trId.equals("H0STCNT0")) {
                 presentSubscribedStocks.remove(stockCode);
             } else {
                 askBidSubscribedStocks.remove(stockCode);
@@ -157,7 +157,7 @@ public class KisWebSocketManager {
 
     // 🆕 전체 구독 해제
     public synchronized void unsubscribeAll(String trId) {
-        if (trId.equals("H0UNCNT0")) {
+        if (trId.equals("H0STCNT0")) {
             if (presentSubscribedStocks.isEmpty()) {
                 System.out.println("체결가 구독 중인 종목이 없습니다.");
                 return;
@@ -170,7 +170,7 @@ public class KisWebSocketManager {
         }
 
         System.out.println(trId + " 전체 구독 해제 시작");
-        Set<String> subscribedStocks = trId.equals("H0UNCNT0") ? presentSubscribedStocks : askBidSubscribedStocks;
+        Set<String> subscribedStocks = trId.equals("H0STCNT0") ? presentSubscribedStocks : askBidSubscribedStocks;
         // 복사본으로 반복 (ConcurrentModificationException 방지)
         Set<String> stocksToUnsubscribe = ConcurrentHashMap.newKeySet();
         stocksToUnsubscribe.addAll(subscribedStocks);
@@ -202,7 +202,7 @@ public class KisWebSocketManager {
         try {
             String json = objectMapper.writeValueAsString(request);
             session.sendMessage(new TextMessage(json));
-            System.out.println((trId.equals("H0UNCNT0") ? "현재가 " : "호가 ") + (trType.equals("1") ? "구독" : "해제") + " 요청 전송: " + stockCode);
+            System.out.println((trId.equals("H0STCNT0") ? "현재가 " : "호가 ") + (trType.equals("1") ? "구독" : "해제") + " 요청 전송: " + stockCode);
         } catch (IOException e) {
             System.err.println("메시지 전송 실패: " + e.getMessage());
         }

--- a/src/main/java/com/antmillion/kis/service/MockDataService.java
+++ b/src/main/java/com/antmillion/kis/service/MockDataService.java
@@ -12,8 +12,8 @@ import java.util.concurrent.*;
 @Service
 public class MockDataService {
     private final SimpMessagingTemplate messagingTemplate;
-    private ScheduledExecutorService scheduler; // ✅ final 제거
-    private ScheduledFuture<?> scheduledTask; // ✅ 추가: 스케줄된 작업 참조
+    private ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> scheduledTask; //추가: 스케줄된 작업 참조
     private final Map<String, MockStockData> mockStocks = new ConcurrentHashMap<>();
     private final Random random = new Random();
     private boolean isRunning = false;
@@ -54,7 +54,7 @@ public class MockDataService {
             return;
         }
 
-        // ✅ 스케줄러 새로 생성 (기존 스케줄러가 없거나 종료된 경우)
+        // 스케줄러 새로 생성 (기존 스케줄러가 없거나 종료된 경우)
         if (scheduler == null || scheduler.isShutdown()) {
             scheduler = Executors.newScheduledThreadPool(1);
             System.out.println("새 스케줄러 생성");
@@ -63,7 +63,7 @@ public class MockDataService {
         isRunning = true;
         System.out.println("Mock 데이터 전송 시작 (종목 수: " + mockStocks.size() + ")");
 
-        // ✅ 1초마다 데이터 전송 (작업 참조 저장)
+        // 1초마다 데이터 전송 (작업 참조 저장)
         scheduledTask = scheduler.scheduleAtFixedRate(() -> {
             try {
                 mockStocks.forEach((stockCode, mockData) -> {
@@ -84,13 +84,13 @@ public class MockDataService {
 
         isRunning = false;
 
-        // ✅ 스케줄된 작업 취소
+        // 스케줄된 작업 취소
         if (scheduledTask != null && !scheduledTask.isCancelled()) {
             scheduledTask.cancel(false);
             System.out.println("Mock 스케줄 작업 취소");
         }
 
-        // ✅ 스케줄러 종료
+        // 스케줄러 종료
         if (scheduler != null && !scheduler.isShutdown()) {
             scheduler.shutdown();
             try {
@@ -113,7 +113,7 @@ public class MockDataService {
         int currentPrice = mockData.getCurrentPrice();
         int priceChange;
 
-        // ✅ 저가 주식 대응
+        // 저가 주식 대응
         if (currentPrice < 100) {
             priceChange = random.nextInt(7) - 3; // -3 ~ +3원
             if (priceChange == 0) {
@@ -135,7 +135,7 @@ public class MockDataService {
 
         int newPrice = currentPrice + priceChange;
 
-        // ✅ 최소 가격 보정
+        // 최소 가격 보정
         if (newPrice < 1) {
             newPrice = 1;
         }

--- a/src/main/java/com/antmillion/kis/service/MockDataService.java
+++ b/src/main/java/com/antmillion/kis/service/MockDataService.java
@@ -1,0 +1,147 @@
+package com.antmillion.kis.service;
+
+import lombok.Getter;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class MockDataService {
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private final Map<String, MockStockData> mockStocks = new ConcurrentHashMap<>();
+    private final Random random = new Random();
+    private boolean isRunning = false;
+
+    public MockDataService(SimpMessagingTemplate messagingTemplate) {
+        this.messagingTemplate = messagingTemplate;
+    }
+
+    // Mock 종목 추가
+    public void addMockStock(String stockCode, int basePrice) {
+        if (!mockStocks.containsKey(stockCode)) {
+            mockStocks.put(stockCode, new MockStockData(stockCode, basePrice));
+            System.out.println("Mock 종목 추가: " + stockCode + " (기준가: " + basePrice + ")");
+        }
+    }
+
+    // Mock 종목 제거
+    public void removeMockStock(String stockCode) {
+        mockStocks.remove(stockCode);
+        System.out.println("Mock 종목 제거: " + stockCode);
+    }
+
+    // 모든 Mock 종목 제거
+    public void clearAllMockStocks() {
+        mockStocks.clear();
+        System.out.println("모든 Mock 종목 제거");
+    }
+
+    // Mock 데이터 전송 시작
+    public void startMockData() {
+        if (isRunning) {
+            System.out.println("Mock 데이터가 이미 실행 중입니다.");
+            return;
+        }
+
+        if (mockStocks.isEmpty()) {
+            System.out.println("Mock 종목이 없습니다. 먼저 종목을 추가하세요.");
+            return;
+        }
+
+        isRunning = true;
+        System.out.println("Mock 데이터 전송 시작 (종목 수: " + mockStocks.size() + ")");
+
+        // 1초마다 랜덤하게 종목 데이터 전송
+        scheduler.scheduleAtFixedRate(() -> {
+            try {
+                mockStocks.forEach((stockCode, mockData) -> {
+                    sendMockTradeData(stockCode, mockData);
+                });
+            } catch (Exception e) {
+                System.err.println("Mock 데이터 전송 오류: " + e.getMessage());
+            }
+        }, 0, 1, TimeUnit.SECONDS);
+    }
+
+    // Mock 데이터 전송 중지
+    public void stopMockData() {
+        if (!isRunning) {
+            System.out.println("Mock 데이터가 실행 중이지 않습니다.");
+            return;
+        }
+
+        isRunning = false;
+        System.out.println("Mock 데이터 전송 중지");
+    }
+
+    // 체결가 Mock 데이터 전송
+    private void sendMockTradeData(String stockCode, MockStockData mockData) {
+        // 가격 변동 (-2% ~ +2%)
+        int currentPrice = mockData.getCurrentPrice();
+        int priceChange = (int) (currentPrice * (random.nextDouble() * 0.04 - 0.02));
+        int newPrice = currentPrice + priceChange;
+
+        // 이전 가격과 비교
+        int prevPrice = mockData.getPreviousPrice();
+        int prdyVrss = newPrice - prevPrice;
+        double prdyCtrt = prevPrice != 0 ? ((double) prdyVrss / prevPrice) * 100 : 0;
+        String prdySign = prdyVrss > 0 ? "+" : (prdyVrss < 0 ? "-" : "");
+
+        // 매수 비율 (40~60%)
+        int shnuRate = 40 + random.nextInt(21);
+
+        Map<String, String> tradeData = new HashMap<>();
+        tradeData.put("mkscShrnIscd", stockCode);
+        tradeData.put("stckPrpr", String.valueOf(newPrice));
+        tradeData.put("prdySign", prdySign);
+        tradeData.put("prdyVrss", String.valueOf(Math.abs(prdyVrss)));
+        tradeData.put("prdyCtrt", String.format("%.2f", Math.abs(prdyCtrt)));
+        tradeData.put("shnuRate", String.valueOf(shnuRate));
+
+        // 현재 가격 업데이트
+        mockData.updatePrice(newPrice);
+
+        // STOMP로 전송
+        messagingTemplate.convertAndSend("/topic/kis-trade/present" + stockCode, tradeData);
+
+        System.out.println("Mock 체결가 전송: " + stockCode + " - " + newPrice + "원");
+    }
+
+    public boolean isRunning() {
+        return isRunning;
+    }
+
+    public int getMockStockCount() {
+        return mockStocks.size();
+    }
+
+    // 내부 클래스: 종목별 Mock 데이터
+    private static class MockStockData {
+        private final String stockCode;
+        private final int basePrice;
+        @Getter
+        private int currentPrice;
+        @Getter
+        private int previousPrice;
+
+        public MockStockData(String stockCode, int basePrice) {
+            this.stockCode = stockCode;
+            this.basePrice = basePrice;
+            this.currentPrice = basePrice;
+            this.previousPrice = basePrice;
+        }
+
+        public void updatePrice(int newPrice) {
+            this.previousPrice = this.currentPrice;
+            this.currentPrice = newPrice;
+        }
+    }
+}

--- a/src/main/java/com/antmillion/kis/service/MockDataService.java
+++ b/src/main/java/com/antmillion/kis/service/MockDataService.java
@@ -7,15 +7,13 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @Service
 public class MockDataService {
     private final SimpMessagingTemplate messagingTemplate;
-    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    private ScheduledExecutorService scheduler; // ✅ final 제거
+    private ScheduledFuture<?> scheduledTask; // ✅ 추가: 스케줄된 작업 참조
     private final Map<String, MockStockData> mockStocks = new ConcurrentHashMap<>();
     private final Random random = new Random();
     private boolean isRunning = false;
@@ -56,11 +54,17 @@ public class MockDataService {
             return;
         }
 
+        // ✅ 스케줄러 새로 생성 (기존 스케줄러가 없거나 종료된 경우)
+        if (scheduler == null || scheduler.isShutdown()) {
+            scheduler = Executors.newScheduledThreadPool(1);
+            System.out.println("새 스케줄러 생성");
+        }
+
         isRunning = true;
         System.out.println("Mock 데이터 전송 시작 (종목 수: " + mockStocks.size() + ")");
 
-        // 1초마다 랜덤하게 종목 데이터 전송
-        scheduler.scheduleAtFixedRate(() -> {
+        // ✅ 1초마다 데이터 전송 (작업 참조 저장)
+        scheduledTask = scheduler.scheduleAtFixedRate(() -> {
             try {
                 mockStocks.forEach((stockCode, mockData) -> {
                     sendMockTradeData(stockCode, mockData);
@@ -79,15 +83,62 @@ public class MockDataService {
         }
 
         isRunning = false;
-        System.out.println("Mock 데이터 전송 중지");
+
+        // ✅ 스케줄된 작업 취소
+        if (scheduledTask != null && !scheduledTask.isCancelled()) {
+            scheduledTask.cancel(false);
+            System.out.println("Mock 스케줄 작업 취소");
+        }
+
+        // ✅ 스케줄러 종료
+        if (scheduler != null && !scheduler.isShutdown()) {
+            scheduler.shutdown();
+            try {
+                // 1초 대기 후 강제 종료
+                if (!scheduler.awaitTermination(1, TimeUnit.SECONDS)) {
+                    scheduler.shutdownNow();
+                }
+                System.out.println("Mock 스케줄러 종료");
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        System.out.println("Mock 데이터 전송 중지 완료");
     }
 
     // 체결가 Mock 데이터 전송
     private void sendMockTradeData(String stockCode, MockStockData mockData) {
-        // 가격 변동 (-2% ~ +2%)
         int currentPrice = mockData.getCurrentPrice();
-        int priceChange = (int) (currentPrice * (random.nextDouble() * 0.04 - 0.02));
+        int priceChange;
+
+        // ✅ 저가 주식 대응
+        if (currentPrice < 100) {
+            priceChange = random.nextInt(7) - 3; // -3 ~ +3원
+            if (priceChange == 0) {
+                priceChange = random.nextBoolean() ? 1 : -1;
+            }
+        }
+        else if (currentPrice < 1000) {
+            priceChange = random.nextInt(11) - 5; // -5 ~ +5원
+            if (priceChange == 0) {
+                priceChange = random.nextBoolean() ? 1 : -1;
+            }
+        }
+        else {
+            priceChange = (int) (currentPrice * (random.nextDouble() * 0.04 - 0.02));
+            if (Math.abs(priceChange) < 10) {
+                priceChange = random.nextBoolean() ? 10 : -10;
+            }
+        }
+
         int newPrice = currentPrice + priceChange;
+
+        // ✅ 최소 가격 보정
+        if (newPrice < 1) {
+            newPrice = 1;
+        }
 
         // 이전 가격과 비교
         int prevPrice = mockData.getPreviousPrice();

--- a/src/main/webapp/WEB-INF/views/main/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main/main.jsp
@@ -204,6 +204,11 @@
 <!-- Adding the standalone version of Lightweight charts -->
 <script src="https://unpkg.com/lightweight-charts/dist/lightweight-charts.standalone.production.js"></script>
 <script> const contextPath = '${cpath}'; </script>
+<!-- SockJS 라이브러리 -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
+
+<!-- STOMP 라이브러리 -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
 <script src="${cpath}/resources/js/main/main.js"></script>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/stocklist/stocklist.jsp
+++ b/src/main/webapp/WEB-INF/views/stocklist/stocklist.jsp
@@ -42,6 +42,12 @@
         </div>
     </main>
 </div>
+<!-- SockJS 라이브러리 -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
+
+<!-- STOMP 라이브러리 -->
+<script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+
 <script>
     // contextPath 변수 설정 (stocklist.js에서 사용)
     var contextPath = '${cpath}';

--- a/src/main/webapp/resources/css/main/main.css
+++ b/src/main/webapp/resources/css/main/main.css
@@ -579,13 +579,13 @@ body {
 }
 
 .main-stocklist-change.positive {
-    color: #fd0000;
-    background-color: #fef2f2;
+    color: var(--color-positive);
+    background-color: rgb(252, 240, 240);
 }
 
 .main-stocklist-change.negative {
-    color: #2563eb;
-    background-color: #eff6ff;
+    color: var(--color-negative);
+    background-color: rgb(237, 244, 253);
 }
 
 .main-stocklist-sentiment {

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -543,12 +543,12 @@ function updateStockRealtimePrice(stockCode, tradeData) {
         changeElement.textContent = tradeData.prdySign + tradeData.prdyCtrt + '%';
 
         // 색상 변경
-        changeElement.classList.remove('main-positive', 'main-negative');
+        changeElement.classList.remove('positive', 'negative');
 
         if (tradeData.prdySign === '+') {
-            changeElement.classList.add('main-positive');
+            changeElement.classList.add('positive');
         } else if (tradeData.prdySign === '-') {
-            changeElement.classList.add('main-negative');
+            changeElement.classList.add('negative');
         }
     }
 

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -51,7 +51,7 @@ function createMainStockItemHTML(stock, index) {
                 <span class="main-stocklist-name">${stock.hts_kor_isnm}</span>
             </div>
             <div class="main-stocklist-price">${currentPrice}</div>
-            <div class="main-stocklist-change">${stock.acml_vol}</div>
+            <div class="main-stocklist-change">-</div>
             <div class="main-stocklist-sentiment">
                 <div class="main-stocklist-sentiment-bar">
                     <div class="main-stocklist-sentiment-buy" style="width: 50%;"></div>

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -2,6 +2,27 @@
    메인 페이지 JavaScript (com.antmillion.main.js)
    =========================== */
 
+var subscribedTopics = {}; // 구독한 토픽 저장 {stockCode: subscription}
+
+// STOMP 연결 (수정 버전)
+function connectStomp() {
+    var url = contextPath + '/ws-stomp';
+    var socket = new SockJS(url);
+    stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, function (frame) {
+        console.log('STOMP 연결 성공: ' + frame);
+
+        // ✅ 수정: 연결 성공 후 종목 리스트 가져오기
+        // (종목 리스트 렌더링 안에서 구독이 자동으로 이뤄짐)
+        renderMainStocks();
+    }, function(error) {
+        console.error('STOMP 연결 실패: ' + error);
+        // 5초 후 재연결 시도
+        setTimeout(connectStomp, 5000);
+    });
+}
+
 // 날짜 포멧 변경
 function formatDate(yyyymmdd) {
     return {
@@ -85,6 +106,10 @@ function renderMainStocks() {
                         //1번 항목의 차트 그리기
                         drawStockMinuteChart(firstStock.mksc_shrn_iscd);
                     }
+
+                    // 종목 리스트 렌더링 완료 후 웹소켓 구독
+                    const stockCodes = data.slice(0, 5).map(stock => stock.mksc_shrn_iscd);
+                    subscribeAllStocksToBackend(stockCodes);
                 });
         });
 }
@@ -179,8 +204,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function initializeMainPage() {
-    // 종목 리스트 렌더링
-    renderMainStocks();
+    connectStomp();
 
     // ✅ 레이아웃 완전 확정 후 차트 초기화
     requestAnimationFrame(() => {
@@ -453,3 +477,155 @@ window.addEventListener('resize', () => {
         stockChart.resize(container.clientWidth, container.clientHeight);
     }
 });
+
+
+// 모든 종목 백엔드 구독 요청
+function subscribeAllStocksToBackend(stockCodes) {
+    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0UNCNT0', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(stockCodes)
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('백엔드 구독 완료:', response);
+
+            // 백엔드 구독 성공 후, 프론트엔드에서 각 종목 STOMP 토픽 구독
+            stockCodes.forEach(stockCode => {
+                subscribeStockTopic(stockCode);
+            });
+        })
+        .catch(error => {
+            console.error('백엔드 구독 실패:', error);
+        });
+}
+
+// 개별 종목 STOMP 토픽 구독
+function subscribeStockTopic(stockCode) {
+    if (subscribedTopics[stockCode]) {
+        console.log('이미 구독 중:', stockCode);
+        return;
+    }
+
+    const topic = '/topic/kis-trade/present' + stockCode;
+    const subscription = stompClient.subscribe(topic, function(message) {
+        const tradeData = JSON.parse(message.body);
+        console.log('실시간 데이터 수신:', tradeData);
+
+        // 화면 업데이트
+        updateStockRealtimePrice(stockCode, tradeData);
+    });
+
+    subscribedTopics[stockCode] = subscription;
+    console.log('토픽 구독 완료:', topic);
+}
+
+// 실시간 가격 화면 업데이트
+function updateStockRealtimePrice(stockCode, tradeData) {
+    // 해당 종목의 DOM 요소 찾기
+    const stockItem = document.querySelector(`.main-stocklist-item[data-id="${stockCode}"]`);
+    if (!stockItem) return;
+
+    // 현재가 업데이트
+    const priceElement = stockItem.querySelector('.main-stocklist-price');
+    if (priceElement) {
+        const price = Number(tradeData.stckPrpr).toLocaleString('ko-KR') + '원';
+        priceElement.textContent = price;
+    }
+
+    // 등락률 업데이트 (main-stocklist-change가 등락률을 표시한다고 가정)
+    const changeElement = stockItem.querySelector('.main-stocklist-change');
+    if (changeElement) {
+        changeElement.textContent = tradeData.prdySign + tradeData.prdyCtrt + '%';
+
+        // 색상 변경
+        changeElement.classList.remove('main-positive', 'main-negative');
+
+        if (tradeData.prdySign === '+') {
+            changeElement.classList.add('main-positive');
+        } else if (tradeData.prdySign === '-') {
+            changeElement.classList.add('main-negative');
+        }
+    }
+
+    // 거래 비율 업데이트 (매수 비율 있으면)
+    if (tradeData.shnuRate) {
+        const buyRate = parseFloat(tradeData.shnuRate);
+        const sellRate = 100 - buyRate;
+
+        const buyBar = stockItem.querySelector('.main-stocklist-sentiment-buy');
+        const sellBar = stockItem.querySelector('.main-stocklist-sentiment-sell');
+        const buyLabel = stockItem.querySelector('.main-stocklist-sentiment-buy-label');
+        const sellLabel = stockItem.querySelector('.main-stocklist-sentiment-sell-label');
+
+        if (buyBar && sellBar) {
+            buyBar.style.width = buyRate + '%';
+            sellBar.style.width = sellRate + '%';
+        }
+
+        if (buyLabel && sellLabel) {
+            buyLabel.textContent = Math.round(buyRate);
+            sellLabel.textContent = Math.round(sellRate);
+        }
+    }
+}
+
+// 페이지 떠날 때 전체 구독 해제
+function unsubscribeAllStocks() {
+    console.log('구독 해제 시작...');
+
+    // 프론트엔드 STOMP 구독 해제
+    for (let stockCode in subscribedTopics) {
+        if (subscribedTopics[stockCode]) {
+            subscribedTopics[stockCode].unsubscribe();
+            console.log('토픽 구독 해제:', stockCode);
+        }
+    }
+    subscribedTopics = {};
+
+    // 백엔드 구독 해제
+    fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0UNCNT0', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        // keepalive: true는 페이지 종료 시에도 요청이 완료되도록 보장
+        keepalive: true
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('백엔드 구독 해제 완료:', response);
+        })
+        .catch(error => {
+            console.error('백엔드 구독 해제 실패:', error);
+        });
+
+    // STOMP 연결 종료
+    if (stompClient !== null && stompClient.connected) {
+        stompClient.disconnect(function() {
+            console.log('STOMP 연결 종료');
+        });
+    }
+}
+
+// beforeunload: 브라우저 닫기, 새로고침, 다른 페이지 이동
+window.addEventListener('beforeunload', function(e) {
+    unsubscribeAllStocks();
+});
+
+// pagehide: 모바일 환경에서도 작동
+window.addEventListener('pagehide', function(e) {
+    unsubscribeAllStocks();
+});
+
+// SPA 환경에서 다른 화면으로 이동하는 경우 사용할 함수
+function navigateToOtherPage(url) {
+    unsubscribeAllStocks();
+
+    // 구독 해제 후 페이지 이동
+    setTimeout(() => {
+        window.location.href = url;
+    }, 100);
+}

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -548,7 +548,7 @@ function updateStockRealtimePrice(stockCode, tradeData) {
             sign = '+';
             signClass = 'positive';
         } else if (tradeData.prdySign === '4' || tradeData.prdySign === '5') {
-            sign = '-';
+            sign = '';
             signClass = 'negative';
         } else {
             sign = '';

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -483,7 +483,7 @@ window.addEventListener('resize', () => {
 
 // 모든 종목 백엔드 구독 요청
 function subscribeAllStocksToBackend(stockCodes) {
-    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0UNCNT0', {
+    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0STCNT0', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -588,7 +588,7 @@ function unsubscribeAllStocks() {
     subscribedTopics = {};
 
     // 백엔드 구독 해제
-    fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0UNCNT0', {
+    fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0STCNT0', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -108,8 +108,10 @@ function renderMainStocks() {
                     }
 
                     // 종목 리스트 렌더링 완료 후 웹소켓 구독
-                    const stockCodes = data.slice(0, 5).map(stock => stock.mksc_shrn_iscd);
-                    subscribeAllStocksToBackend(stockCodes);
+                    if (!isMockMode) {
+                        const stockCodes = data.slice(0, 5).map(stock => stock.mksc_shrn_iscd);
+                        subscribeAllStocksToBackend(stockCodes);
+                    }
                 });
         });
 }
@@ -629,3 +631,101 @@ function navigateToOtherPage(url) {
         window.location.href = url;
     }, 100);
 }
+
+// ========== Mock 데이터 제어 함수 (main.js 맨 아래 추가) ==========
+
+let isMockMode = false; // Mock 모드 플래그
+
+// Mock 모드로 전환 (한투 구독 건너뛰고 Mock만 사용)
+function enableMockMode() {
+    isMockMode = true;
+    console.log('Mock 모드 활성화');
+
+    // 현재 화면에 표시된 종목 리스트 가져오기
+    const stockItems = document.querySelectorAll('.main-stocklist-item');
+    const mockStocks = [];
+
+    stockItems.forEach(item => {
+        const stockCode = item.getAttribute('data-id');
+        const priceText = item.querySelector('.main-stocklist-price').textContent;
+        const basePrice = parseInt(priceText.replace(/[^0-9]/g, ''));
+
+        mockStocks.push({
+            stockCode: stockCode,
+            basePrice: basePrice
+        });
+    });
+
+    // Mock 종목 등록
+    fetch(contextPath + '/api/kis/mock/add-stocks', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(mockStocks)
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 종목 등록:', response);
+
+            // Mock 데이터 전송 시작
+            return fetch(contextPath + '/api/kis/mock/start', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 데이터 시작:', response);
+
+            // STOMP 구독만 진행 (한투 백엔드 구독은 건너뜀)
+            const stockCodes = mockStocks.map(s => s.stockCode);
+            stockCodes.forEach(stockCode => {
+                subscribeStockTopic(stockCode);
+            });
+
+            alert('테스트 모드 시작! 한투 연결 없이 가짜 데이터로 테스트합니다.');
+        })
+        .catch(error => {
+            console.error('Mock 모드 활성화 실패:', error);
+        });
+}
+
+// Mock 모드 비활성화
+function disableMockMode() {
+    isMockMode = false;
+
+    // Mock 데이터 중지
+    fetch(contextPath + '/api/kis/mock/stop', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 데이터 중지:', response);
+
+            // Mock 종목 제거
+            return fetch(contextPath + '/api/kis/mock/clear', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 종목 제거:', response);
+            alert('테스트 모드 종료! 실제 모드로 전환하려면 페이지를 새로고침하세요.');
+        })
+        .catch(error => {
+            console.error('Mock 모드 비활성화 실패:', error);
+        });
+}
+
+// 브라우저 콘솔에서 사용 가능하도록 전역으로 노출
+window.enableMockMode = enableMockMode;
+window.disableMockMode = disableMockMode;

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -540,21 +540,33 @@ function updateStockRealtimePrice(stockCode, tradeData) {
     // 등락률 업데이트 (main-stocklist-change가 등락률을 표시한다고 가정)
     const changeElement = stockItem.querySelector('.main-stocklist-change');
     if (changeElement) {
-        changeElement.textContent = tradeData.prdySign + tradeData.prdyCtrt + '%';
+        // 1,2: 상승(+), 3: 보합(0), 4,5: 하락(-)
+        let sign = '';
+        let signClass = '';
+
+        if (tradeData.prdySign === '1' || tradeData.prdySign === '2') {
+            sign = '+';
+            signClass = 'positive';
+        } else if (tradeData.prdySign === '4' || tradeData.prdySign === '5') {
+            sign = '-';
+            signClass = 'negative';
+        } else {
+            sign = '';
+            signClass = '';
+        }
+
+        changeElement.textContent = sign + tradeData.prdyCtrt + '%';
 
         // 색상 변경
         changeElement.classList.remove('positive', 'negative');
-
-        if (tradeData.prdySign === '+') {
-            changeElement.classList.add('positive');
-        } else if (tradeData.prdySign === '-') {
-            changeElement.classList.add('negative');
+        if (signClass) {
+            changeElement.classList.add(signClass);
         }
     }
 
     // 거래 비율 업데이트 (매수 비율 있으면)
     if (tradeData.shnuRate) {
-        const buyRate = parseFloat(tradeData.shnuRate);
+        const buyRate = parseFloat(tradeData.shnuRate) * 100;
         const sellRate = 100 - buyRate;
 
         const buyBar = stockItem.querySelector('.main-stocklist-sentiment-buy');

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -108,21 +108,33 @@ function updateStockRealtimePrice(stockCode, tradeData) {
     // 등락률 업데이트
     const changeElement = stockItem.querySelector('.stocklist-change');
     if (changeElement) {
-        changeElement.textContent = tradeData.prdySign + tradeData.prdyCtrt + '%';
+        // 1,2: 상승(+), 3: 보합(0), 4,5: 하락(-)
+        let sign = '';
+        let signClass = '';
+
+        if (tradeData.prdySign === '1' || tradeData.prdySign === '2') {
+            sign = '+';
+            signClass = 'positive';
+        } else if (tradeData.prdySign === '4' || tradeData.prdySign === '5') {
+            sign = '-';
+            signClass = 'negative';
+        } else {
+            sign = '';
+            signClass = '';
+        }
+
+        changeElement.textContent = sign + tradeData.prdyCtrt + '%';
 
         // 색상 변경
         changeElement.classList.remove('positive', 'negative');
-
-        if (tradeData.prdySign === '+') {
-            changeElement.classList.add('positive');
-        } else if (tradeData.prdySign === '-') {
-            changeElement.classList.add('negative');
+        if (signClass) {
+            changeElement.classList.add(signClass);
         }
     }
 
     // 거래 비율 업데이트
     if (tradeData.shnuRate) {
-        const buyRate = parseFloat(tradeData.shnuRate);
+        const buyRate = parseFloat(tradeData.shnuRate) * 100;
         const sellRate = 100 - buyRate;
 
         const buyBar = stockItem.querySelector('.stocklist-sentiment-buy');

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -7,13 +7,186 @@ let currentPage = 1;
 const itemsPerPage = 10;
 let totalPages = 1;
 
+// STOMP 관련 변수
+let stompClient = null;
+let subscribedTopics = {}; // 구독한 토픽 저장 {stockCode: subscription}
+let currentStockCodes = []; // 현재 화면에 표시된 종목 코드들
+
 // 임시 account_id (로그인 기능 완성 전까지)
 const TEMP_ACCOUNT_ID = 3;
 
-// 종목 아이템 HTML 생성 함수
+// ========== STOMP 연결 ==========
+function connectStomp() {
+    const url = contextPath + '/ws-stomp';
+    const socket = new SockJS(url);
+    stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, function (frame) {
+        console.log('STOMP 연결 성공: ' + frame);
+
+        // 연결 성공 후 현재 화면의 종목들 구독
+        if (currentStockCodes.length > 0) {
+            subscribeCurrentStocks();
+        }
+    }, function(error) {
+        console.error('STOMP 연결 실패: ' + error);
+        // 5초 후 재연결 시도
+        setTimeout(connectStomp, 5000);
+    });
+}
+
+// ========== 현재 화면 종목들 구독 ==========
+function subscribeCurrentStocks() {
+    // 기존 구독 모두 해제
+    unsubscribeAllStocks();
+
+    if (currentStockCodes.length === 0) return;
+
+    // ✅ Mock 모드일 때는 한투 백엔드 구독 건너뛰고 STOMP만 구독
+    if (isMockMode) {
+        console.log('Mock 모드 - STOMP 구독만 진행');
+        currentStockCodes.forEach(stockCode => {
+            subscribeStockTopic(stockCode);
+        });
+        return;
+    }
+
+    // 백엔드에 구독 요청
+    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0UNCNT0', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(currentStockCodes)
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('백엔드 구독 완료:', response);
+
+            // 프론트엔드 STOMP 토픽 구독
+            currentStockCodes.forEach(stockCode => {
+                subscribeStockTopic(stockCode);
+            });
+        })
+        .catch(error => {
+            console.error('백엔드 구독 실패:', error);
+        });
+}
+
+// ========== 개별 종목 STOMP 토픽 구독 ==========
+function subscribeStockTopic(stockCode) {
+    if (subscribedTopics[stockCode]) {
+        console.log('이미 구독 중:', stockCode);
+        return;
+    }
+
+    const topic = '/topic/kis-trade/present' + stockCode;
+    const subscription = stompClient.subscribe(topic, function(message) {
+        const tradeData = JSON.parse(message.body);
+        console.log('실시간 데이터 수신:', tradeData);
+
+        // 화면 업데이트
+        updateStockRealtimePrice(stockCode, tradeData);
+    });
+
+    subscribedTopics[stockCode] = subscription;
+    console.log('토픽 구독 완료:', topic);
+}
+
+// ========== 실시간 가격 화면 업데이트 ==========
+function updateStockRealtimePrice(stockCode, tradeData) {
+    const stockItem = document.querySelector(`.stocklist-item[data-code="${stockCode}"]`);
+    if (!stockItem) return;
+
+    // 현재가 업데이트
+    const priceElement = stockItem.querySelector('.stocklist-price');
+    if (priceElement) {
+        const price = Number(tradeData.stckPrpr).toLocaleString('ko-KR') + '원';
+        priceElement.textContent = price;
+    }
+
+    // 등락률 업데이트
+    const changeElement = stockItem.querySelector('.stocklist-change');
+    if (changeElement) {
+        changeElement.textContent = tradeData.prdySign + tradeData.prdyCtrt + '%';
+
+        // 색상 변경
+        changeElement.classList.remove('positive', 'negative');
+
+        if (tradeData.prdySign === '+') {
+            changeElement.classList.add('positive');
+        } else if (tradeData.prdySign === '-') {
+            changeElement.classList.add('negative');
+        }
+    }
+
+    // 거래 비율 업데이트
+    if (tradeData.shnuRate) {
+        const buyRate = parseFloat(tradeData.shnuRate);
+        const sellRate = 100 - buyRate;
+
+        const buyBar = stockItem.querySelector('.stocklist-sentiment-buy');
+        const sellBar = stockItem.querySelector('.stocklist-sentiment-sell');
+        const buyLabel = stockItem.querySelector('.stocklist-sentiment-buy-label');
+        const sellLabel = stockItem.querySelector('.stocklist-sentiment-sell-label');
+
+        if (buyBar && sellBar) {
+            buyBar.style.width = buyRate + '%';
+            sellBar.style.width = sellRate + '%';
+        }
+
+        if (buyLabel && sellLabel) {
+            buyLabel.textContent = Math.round(buyRate);
+            sellLabel.textContent = Math.round(sellRate);
+        }
+    }
+}
+
+// ========== 모든 구독 해제 ==========
+function unsubscribeAllStocks() {
+    console.log('구독 해제 시작...');
+
+    // 프론트엔드 STOMP 구독 해제
+    for (let stockCode in subscribedTopics) {
+        if (subscribedTopics[stockCode]) {
+            subscribedTopics[stockCode].unsubscribe();
+            console.log('토픽 구독 해제:', stockCode);
+        }
+    }
+    subscribedTopics = {};
+
+    // 백엔드 구독 해제
+    if (currentStockCodes.length > 0) {
+        fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0UNCNT0', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            keepalive: true
+        })
+            .then(res => res.json())
+            .then(response => {
+                console.log('백엔드 구독 해제 완료:', response);
+            })
+            .catch(error => {
+                console.error('백엔드 구독 해제 실패:', error);
+            });
+    }
+}
+
+// ========== 종목 아이템 HTML 생성 함수 ==========
 function createStockItemHTML(stock, index, isFavorite) {
     const favoriteIcon = isFavorite ? '♥' : '♡';
     const favoriteClass = isFavorite ? 'active' : '';
+
+    // 현재가 포맷팅
+    const currentPrice = Number(stock.stck_prpr || 0).toLocaleString('ko-KR') + '원';
+
+    // 등락률 계산
+    const priceChange = Number(stock.prdy_vrss || 0);
+    const changeRate = Number(stock.prdy_ctrt || 0);
+    const changeSign = priceChange > 0 ? '+' : (priceChange < 0 ? '-' : '');
+    const changeClass = priceChange > 0 ? 'positive' : (priceChange < 0 ? 'negative' : '');
 
     return `
         <div class="stocklist-item" data-code="${stock.mksc_shrn_iscd}">
@@ -28,8 +201,8 @@ function createStockItemHTML(stock, index, isFavorite) {
                 </div>
                 <span class="stocklist-name">${stock.hts_kor_isnm}</span>
             </div>
-            <div class="stocklist-price">${stock.stck_prpr}</div>
-            <div class="stocklist-change">${stock.acml_vol}</div>
+            <div class="stocklist-price">${currentPrice}</div>
+            <div class="stocklist-change ${changeClass}">${changeSign}${Math.abs(changeRate).toFixed(2)}%</div>
             <div class="stocklist-sentiment">
                 <div class="stocklist-sentiment-bar">
                     <div class="stocklist-sentiment-buy" style="width: 50%;"></div>
@@ -44,7 +217,7 @@ function createStockItemHTML(stock, index, isFavorite) {
     `;
 }
 
-// 전체 종목 렌더링 (페이징)
+// ========== 전체 종목 렌더링 (페이징) ==========
 function renderAllStocks() {
     const container = document.getElementById('stocklist-Container');
 
@@ -53,6 +226,9 @@ function renderAllStocks() {
         .then(responseData => {
             const stocks = responseData.data;
             totalPages = responseData.totalPages;
+
+            // 현재 화면의 종목 코드들 저장
+            currentStockCodes = stocks.map(stock => stock.mksc_shrn_iscd);
 
             // 관심종목 목록 가져오기
             return fetch(`${contextPath}/api/interest/list`)
@@ -72,6 +248,11 @@ function renderAllStocks() {
                     // 이벤트 리스너 재등록
                     attachFavoriteListeners();
                     attachStockItemListeners();
+
+                    // STOMP 연결 확인 후 구독
+                    if (stompClient && stompClient.connected) {
+                        subscribeCurrentStocks();
+                    }
                 });
         })
         .catch(error => {
@@ -80,7 +261,7 @@ function renderAllStocks() {
         });
 }
 
-// 관심종목 렌더링
+// ========== 관심종목 렌더링 ==========
 function renderFavoriteStocks() {
     const container = document.getElementById('stocklist-Container');
 
@@ -91,8 +272,13 @@ function renderFavoriteStocks() {
             if (interestCodes.length === 0) {
                 container.innerHTML = '<p style="text-align: center; padding: 40px; color: #9CA3AF;">관심종목이 없습니다.</p>';
                 document.getElementById('pagination-container')?.remove();
+                currentStockCodes = [];
+                unsubscribeAllStocks();
                 return;
             }
+
+            // 현재 화면의 종목 코드들 저장
+            currentStockCodes = interestCodes;
 
             // 관심종목 코드로 종목 정보 가져오기
             return fetch(`${contextPath}/api/kis/stocksByCode`, {
@@ -116,6 +302,11 @@ function renderFavoriteStocks() {
                     // 이벤트 리스너 재등록
                     attachFavoriteListeners();
                     attachStockItemListeners();
+
+                    // STOMP 연결 확인 후 구독
+                    if (stompClient && stompClient.connected) {
+                        subscribeCurrentStocks();
+                    }
                 });
         })
         .catch(error => {
@@ -124,7 +315,7 @@ function renderFavoriteStocks() {
         });
 }
 
-// 종목 리스트 렌더링 (탭에 따라 분기)
+// ========== 종목 리스트 렌더링 (탭에 따라 분기) ==========
 function renderStocks() {
     if (currentTab === 'all') {
         renderAllStocks();
@@ -133,7 +324,7 @@ function renderStocks() {
     }
 }
 
-// 페이지네이션 렌더링
+// ========== 페이지네이션 렌더링 ==========
 function renderPagination() {
     // 기존 페이지네이션 제거
     const existingPagination = document.getElementById('pagination-container');
@@ -181,7 +372,7 @@ function renderPagination() {
     });
 }
 
-// 즐겨찾기 버튼 이벤트 리스너 등록
+// ========== 즐겨찾기 버튼 이벤트 리스너 등록 ==========
 function attachFavoriteListeners() {
     document.querySelectorAll('.stocklist-favorite-btn').forEach(btn => {
         btn.addEventListener('click', function(e) {
@@ -216,7 +407,7 @@ function attachFavoriteListeners() {
     });
 }
 
-// 종목 아이템 클릭 이벤트 리스너 등록
+// ========== 종목 아이템 클릭 이벤트 리스너 등록 ==========
 function attachStockItemListeners() {
     document.querySelectorAll('.stocklist-item').forEach(item => {
         item.addEventListener('click', function(e) {
@@ -231,7 +422,7 @@ function attachStockItemListeners() {
     });
 }
 
-// 탭 전환 이벤트
+// ========== 탭 전환 이벤트 ==========
 document.querySelectorAll('.stocklist-tab-btn').forEach((btn, index) => {
     btn.addEventListener('click', function() {
         document.querySelectorAll('.stocklist-tab-btn').forEach(b => b.classList.remove('active'));
@@ -244,7 +435,139 @@ document.querySelectorAll('.stocklist-tab-btn').forEach((btn, index) => {
     });
 });
 
-// 초기 렌더링
+// ========== 페이지 떠날 때 전체 구독 해제 ==========
+window.addEventListener('beforeunload', function(e) {
+    unsubscribeAllStocks();
+
+    if (stompClient !== null && stompClient.connected) {
+        stompClient.disconnect(function() {
+            console.log('STOMP 연결 종료');
+        });
+    }
+});
+
+window.addEventListener('pagehide', function(e) {
+    unsubscribeAllStocks();
+});
+
+// ========== 초기화 ==========
 document.addEventListener('DOMContentLoaded', function() {
+    // STOMP 연결
+    connectStomp();
+
+    // 초기 렌더링
     renderStocks();
 });
+
+// ========== Mock 데이터 제어 함수 ==========
+
+let isMockMode = false; // Mock 모드 플래그
+
+// Mock 모드로 전환 (한투 구독 건너뛰고 Mock만 사용)
+function enableMockMode() {
+    isMockMode = true;
+    console.log('Mock 모드 활성화');
+
+    // 현재 화면에 표시된 종목 리스트 가져오기
+    const stockItems = document.querySelectorAll('.stocklist-item');
+    const mockStocks = [];
+
+    stockItems.forEach(item => {
+        const stockCode = item.getAttribute('data-code');
+        const priceText = item.querySelector('.stocklist-price').textContent;
+        const basePrice = parseInt(priceText.replace(/[^0-9]/g, ''));
+
+        mockStocks.push({
+            stockCode: stockCode,
+            basePrice: basePrice
+        });
+    });
+
+    // Mock 종목 등록
+    fetch(contextPath + '/api/kis/mock/add-stocks', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(mockStocks)
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 종목 등록:', response);
+
+            // Mock 데이터 전송 시작
+            return fetch(contextPath + '/api/kis/mock/start', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 데이터 시작:', response);
+
+            // STOMP 구독만 진행 (한투 백엔드 구독은 건너뜀)
+            const stockCodes = mockStocks.map(s => s.stockCode);
+            stockCodes.forEach(stockCode => {
+                subscribeStockTopic(stockCode);
+            });
+
+            alert('테스트 모드 시작! 한투 연결 없이 가짜 데이터로 테스트합니다.');
+        })
+        .catch(error => {
+            console.error('Mock 모드 활성화 실패:', error);
+        });
+}
+
+// Mock 모드 비활성화
+function disableMockMode() {
+    isMockMode = false;
+
+    // Mock 데이터 중지
+    fetch(contextPath + '/api/kis/mock/stop', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 데이터 중지:', response);
+
+            // Mock 종목 제거
+            return fetch(contextPath + '/api/kis/mock/clear', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+        })
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 종목 제거:', response);
+            alert('테스트 모드 종료! 실제 모드로 전환하려면 페이지를 새로고침하세요.');
+        })
+        .catch(error => {
+            console.error('Mock 모드 비활성화 실패:', error);
+        });
+}
+
+// Mock 상태 확인
+function checkMockStatus() {
+    fetch(contextPath + '/api/kis/mock/status')
+        .then(res => res.json())
+        .then(response => {
+            console.log('Mock 상태:', response.isRunning ? '실행 중' : '중지됨');
+            console.log('Mock 종목 수:', response.stockCount);
+            alert('테스트 데이터 상태: ' + (response.isRunning ? '실행 중' : '중지됨') + '\n종목 수: ' + response.stockCount);
+        })
+        .catch(error => {
+            console.error('Mock 상태 확인 실패:', error);
+        });
+}
+
+// 브라우저 콘솔에서 사용 가능하도록 전역으로 노출
+window.enableMockMode = enableMockMode;
+window.disableMockMode = disableMockMode;
+window.checkMockStatus = checkMockStatus;

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -116,7 +116,7 @@ function updateStockRealtimePrice(stockCode, tradeData) {
             sign = '+';
             signClass = 'positive';
         } else if (tradeData.prdySign === '4' || tradeData.prdySign === '5') {
-            sign = '-';
+            sign = '';
             signClass = 'negative';
         } else {
             sign = '';

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -52,7 +52,7 @@ function subscribeCurrentStocks() {
     }
 
     // 백엔드에 구독 요청
-    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0UNCNT0', {
+    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0STCNT0', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'
@@ -157,7 +157,7 @@ function unsubscribeAllStocks() {
 
     // 백엔드 구독 해제
     if (currentStockCodes.length > 0) {
-        fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0UNCNT0', {
+        fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0STCNT0', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #165 

---

### 📝 작업 내용
- 메인 화면에 웹소켓으로 얻어오는 실시간 현재가가 표시되게 하였습니다.
- 종목리스트 화면에도 마찬가지로 실시간 현재가, 등락률, 거래 비율 표시되게 하였습니다.
- 평일 장시간 외 혹은 주말에 테스트할 수 있게 한투에서 오는 데이터와 유사한 Mock 데이터를 1초마다 생성하여 동일한 STOMP를 통해 전송하게 하였습니다. 서버 실행 후 f12 누른 후 콘솔에 enableMockMode(); 를 입력하면 Mock 데이터로 main 화면에 실시간으로 데이터가 바뀌는 것을 확인할 수 있습니다.

---

### 📷 스크린샷 (선택)
Mock 데이터를 이용하여 메인 화면 실시간 현재가 변동 확인
<video src="https://github.com/user-attachments/assets/c7d306d1-a0c4-4d8c-8268-7af051cc086c" controls></video>

Mock 데이터를 이용하여 종목 리스트 화면 실시간 현재가 변동 확인
<video src="https://github.com/user-attachments/assets/97d3b765-ce0d-469c-a7b3-0a6b70adb198" controls></video>



---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
