### PR TITLE
Feat: 퀴즈 정답 제출 후 정답에 대한 설명 모달 기능 구현

### DIFF
--- a/src/main/java/com/antmillion/mission/controller/MissionController.java
+++ b/src/main/java/com/antmillion/mission/controller/MissionController.java
@@ -2,11 +2,10 @@ package com.antmillion.mission.controller;
 
 import com.antmillion.mission.dto.QuizQuestionResponseDTO;
 import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
+import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
 import com.antmillion.mission.service.MissionService;
 import com.antmillion.user.dto.UserRankResponseDTO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,13 +41,17 @@ public class MissionController {
 
     @PostMapping("/check")
     @ResponseBody
-    public boolean checkAnswer(@RequestBody QuizSubmissionRequestDTO requestDTO) {
+    public QuizSubmissionResponseDTO checkAnswer(@RequestBody QuizSubmissionRequestDTO requestDTO) {
         try {
             return missionService.checkAndLogAnswer(requestDTO);
         } catch (Exception e) {
             System.err.println("퀴즈 채점 중 오류: " + e.getMessage());
             e.printStackTrace();
-            return false;
+            return QuizSubmissionResponseDTO.builder()
+                    .isCorrect(false)
+                    .point(0)
+                    .message("오류가 발생했습니다. 다시 시도해주세요.")
+                    .build();
         }
     }
 

--- a/src/main/java/com/antmillion/mission/dto/QuizResultDTO.java
+++ b/src/main/java/com/antmillion/mission/dto/QuizResultDTO.java
@@ -1,0 +1,13 @@
+package com.antmillion.mission.dto;
+
+import lombok.*;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class QuizResultDTO {
+    private Integer answer;
+    private String explanation;
+    private Integer point;
+}

--- a/src/main/java/com/antmillion/mission/dto/QuizSubmissionResponseDTO.java
+++ b/src/main/java/com/antmillion/mission/dto/QuizSubmissionResponseDTO.java
@@ -1,0 +1,15 @@
+package com.antmillion.mission.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class QuizSubmissionResponseDTO {
+    @JsonProperty("isCorrect")
+    private boolean isCorrect;
+    private Integer point;
+    private String message;
+}

--- a/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
+++ b/src/main/java/com/antmillion/mission/mapper/MissionMapper.java
@@ -3,6 +3,7 @@ package com.antmillion.mission.mapper;
 import com.antmillion.mission.dto.QuizChoiceDTO;
 import com.antmillion.mission.dto.QuizLogDTO;
 import com.antmillion.mission.dto.QuizQuestionDTO;
+import com.antmillion.mission.dto.QuizResultDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
@@ -22,15 +23,12 @@ public interface MissionMapper {
     // 퀴즈 풀이 이력 저장
     void insertQuizLog(QuizLogDTO quizLog);
 
-    // 정답 번호 조회
-    Integer selectAnswerByQuizId(@Param("quizId") Long quizId);
-
     // 어떤 문제를 풀었는지 확인
     List<Long> selectTodaySolvedQuizIds(@Param("userId") Long userId);
 
-    // 퀴즈 포인트 조회
-    int selectQuizPointByQuizId(@Param("quizId") Long quizId);
-
     // 오늘 미션 완료 여부 조회
     int countTodaySolvedQuiz(@Param("userId") Long userId);
+
+    // 퀴즈 정답, 포인트, 설명 조회
+    QuizResultDTO selectQuizResultByQuizId(@Param("quizId") Long quizId);
 }

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -2,13 +2,14 @@ package com.antmillion.mission.service;
 
 import com.antmillion.mission.dto.QuizQuestionResponseDTO;
 import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
+import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
 import com.antmillion.user.dto.UserRankResponseDTO;
 
 import java.util.List;
 
 public interface MissionService {
     List<QuizQuestionResponseDTO> getDailyQuiz();
-    boolean checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO);
+    QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO);
     UserRankResponseDTO getUserMissionStatus(Long userId);
     Long getCurrentUserId();
     boolean isTodayMissionCompleted(Long userId);

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -96,15 +96,15 @@ public class MissionServiceImpl implements MissionService {
 
     @Override
     @Transactional
-    public boolean checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO) {
+    public QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO) {
         // 해당 퀴즈의 정답 조회
-        Integer realAnswer = missionMapper.selectAnswerByQuizId(requestDTO.getQuizId());
-        if (realAnswer == null) {
+        QuizResultDTO resultInfo = missionMapper.selectQuizResultByQuizId(requestDTO.getQuizId());
+        if (resultInfo == null || resultInfo.getAnswer() == null) {
             throw new IllegalArgumentException("존재하지 않는 퀴즈입니다.");
         }
 
         // 채점
-        boolean isCorrect = realAnswer.equals(requestDTO.getChoiceNo());
+        boolean isCorrect = resultInfo.getAnswer().equals(requestDTO.getChoiceNo());
         if(isCorrect) {
             try {
                 int count = missionMapper.countSolvedHistory(requestDTO.getUserId(), requestDTO.getQuizId());
@@ -115,24 +115,32 @@ public class MissionServiceImpl implements MissionService {
                             .build();
                     missionMapper.insertQuizLog(logDTO);
 
-                    // 포인트 조회
-                    int quizPoint = missionMapper.selectQuizPointByQuizId(requestDTO.getQuizId());
-
                     // 포인트 지급
-                    memberMapper.updateUserPoint(requestDTO.getUserId(), quizPoint);
+                    memberMapper.updateUserPoint(requestDTO.getUserId(), resultInfo.getPoint());
 
                     // 랭크 갱신
                     Long userId = requestDTO.getUserId();
                     int newPoint = memberMapper.selectUserPoint(userId);
                     antRankService.updateUserRank(userId, newPoint);
                 }
+                // 정답 응답
+                return QuizSubmissionResponseDTO.builder()
+                        .isCorrect(true)
+                        .point(resultInfo.getPoint())
+                        .message(resultInfo.getExplanation())
+                        .build();
             } catch (Exception e) {
                 System.err.println("퀴즈 로그 저장 중 오류: " + e.getMessage());
                 e.printStackTrace();
                 throw new RuntimeException("퀴즈 처리 중 오류가 발생했습니다.", e);
             }
         }
-        return isCorrect;
+        // 오답 응답
+        return QuizSubmissionResponseDTO.builder()
+                .isCorrect(false)
+                .point(0)
+                .message("다시 한번 생각해 보세요.")
+                .build();
     }
 
     @Override

--- a/src/main/resources/mappers/mission/MissionMapper.xml
+++ b/src/main/resources/mappers/mission/MissionMapper.xml
@@ -68,22 +68,22 @@
         AND DATE_FORMAT(solved_at, '%Y-%m-%d') = CURDATE()
     </select>
 
-    <select id="selectAnswerByQuizId" resultType="Integer">
-        SELECT answer
-        FROM quiz_question
-        WHERE quiz_id = #{quizId}
-    </select>
-
-    <select id="selectQuizPointByQuizId" resultType="int">
-        SELECT point
-        FROM quiz_question
-        WHERE quiz_id = #{quizId}
-    </select>
-
     <select id="countTodaySolvedQuiz" resultType="int">
         SELECT COUNT(DISTINCT quiz_id)
         FROM quiz_log
         WHERE user_id = #{userId}
         AND DATE(solved_at) = CURDATE()
+    </select>
+
+    <resultMap id="quizResultMap" type="com.antmillion.mission.dto.QuizResultDTO">
+        <result property="answer" column="answer"/>
+        <result property="explanation" column="explanation"/>
+        <result property="point" column="point"/>
+    </resultMap>
+
+    <select id="selectQuizResultByQuizId" resultMap="quizResultMap">
+        SELECT answer, explanation, point
+        FROM quiz_question
+        WHERE quiz_id = #{quizId}
     </select>
 </mapper>

--- a/src/main/webapp/WEB-INF/views/mission/mission.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/mission.jsp
@@ -33,9 +33,6 @@
 			<div class="mission-quiz-card" id="mission-quizCard">
 				<div class="mission-quiz-header">
 					<h3 class="mission-quiz-date"></h3>
-					<!-- 포인트 메시지 -->
-					<div class="mission-points-message" id="mission-pointsMessage"
-						style="display: none;">100 포인트 획득하였습니다.</div>
 				</div>
 				<div id="mission-quizContent">
 					<div class="mission-quiz-question" id="mission-quizQuestion"></div>
@@ -80,12 +77,18 @@
 			</div>
 		</main>
 
-		<!-- 오답 모달 -->
-		<div class="mission-modal" id="mission-wrongModal">
+		<!-- 결과(정답/오답) 모달 -->
+		<div class="mission-modal" id="mission-result-Modal">
 			<div class="mission-modal-content">
-				<button class="mission-modal-close" onclick="closeModal()">✕</button>
-				<h2 class="mission-modal-title">다시 한번 생각해보세요.</h2>
-				<p class="mission-modal-message">퀴즈를 맞히고 똑똑한개미 랭크를 높여보세요!</p>
+				<div class="mission-modal-header">
+					<button class="mission-modal-close" onclick="closeModal()">✕</button>
+				</div>
+				<div class="mission-modal-body">
+					<!-- 포인트 메시지 -->
+					<div class="mission-points-message" id="mission-pointsMessage" style="display: none;"></div>
+					<h2 class="mission-modal-title"></h2>
+					<p class="mission-modal-message"></p>
+				</div>
 			</div>
 		</div>
 		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>

--- a/src/main/webapp/resources/css/mission/mission.css
+++ b/src/main/webapp/resources/css/mission/mission.css
@@ -128,7 +128,7 @@ body {
 }
 
 .mission-quiz-question {
-	font-size: 24px;
+	font-size: 30px;
 	font-weight: 700;
 	text-align: center;
 	margin-bottom: 50px;
@@ -148,7 +148,7 @@ body {
 
 .mission-option-btn {
 	padding: 24px;
-	font-size: 16px;
+	font-size: 24px;
 	font-weight: 600;
 	background-color: var(--primary-bg);
 	border: 1px solid var(--border-color);
@@ -188,22 +188,6 @@ body {
 	40%, 60% { transform: translate3d(4px, 0, 0); }
 }
 
-/* 포인트 메시지 */
-.mission-points-message {
-	position: absolute;
-	right: 0;
-	top: 0;
-	background-color: #2970ff;
-	color: white;
-	padding: 8px 16px;
-	border-radius: 50px;
-	font-size: 14px;
-	font-weight: 600;
-	box-shadow: 0 4px 12px rgba(41, 112, 255, 0.3);
-	animation: slideIn 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-	z-index: 100;
-}
-
 @keyframes slideIn {
 	from {
 		transform: translateX(20px);
@@ -223,11 +207,11 @@ body {
 	left: 0;
 	width: 100%;
 	height: 100%;
+	padding: 60px;
 	background-color: rgba(0, 0, 0, 0.5);
 	z-index: 2000;
 	align-items: center;
 	justify-content: center;
-	backdrop-filter: blur(4px);
 }
 
 .mission-modal.active {
@@ -237,13 +221,13 @@ body {
 .mission-modal-content {
 	background: var(--secondary-bg);
 	border-radius: 24px;
-	padding: 40px;
-	text-align: center;
 	position: relative;
-	max-width: 400px;
-	width: 90%;
+	max-width: 500px;
+	width: 100%;
 	box-shadow: var(--shadow-md);
 	animation: modalPop 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+	overflow: hidden;
+	padding: 5px 20px 20px 20px;
 }
 
 @keyframes modalPop {
@@ -257,10 +241,15 @@ body {
 	}
 }
 
+.mission-modal-header {
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	padding: 16px 16px 0;
+	min-height: 48px;
+}
+
 .mission-modal-close {
-	position: absolute;
-	top: 16px;
-	right: 16px;
 	font-size: 20px;
 	width: 32px;
 	height: 32px;
@@ -281,15 +270,51 @@ body {
 	color: var(--text-primary);
 }
 
+.mission-modal-body {
+	padding: 0 40px 40px;
+	text-align: center;
+}
+
+.mission-points-message {
+	display: block;
+	background: linear-gradient(135deg, #2970ff 0%, #1e5dd8 100%);
+	color: white;
+	padding: 10px 10px;
+	border-radius: 50px;
+	font-size: 14px;
+	font-weight: 600;
+	box-shadow: 0 4px 12px rgba(41, 112, 255, 0.3);
+	margin-bottom: 20px;
+	position: static;
+	animation: bounceIn 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+@keyframes bounceIn {
+	0% {
+		transform: scale(0.3);
+		opacity: 0;
+	}
+	50% {
+		transform: scale(1.05);
+	}
+	70% {
+		transform: scale(0.9);
+	}
+	100% {
+		transform: scale(1);
+		opacity: 1;
+	}
+}
+
 .mission-modal-title {
-	font-size: 22px;
+	font-size: 28px;
 	font-weight: 700;
 	margin-bottom: 12px;
 	color: var(--text-primary);
 }
 
 .mission-modal-message {
-	font-size: 15px;
+	font-size: 20px;
 	color: var(--text-secondary);
 	line-height: 1.5;
 	word-break: keep-all;

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -106,40 +106,23 @@ function selectOption(optionId, ignore, buttonElement) {
 }
 
 // 정답 처리
-function handleCorrectAnswer(buttonElement, optionId) {
+function handleCorrectAnswer(buttonElement, optionId, response) {
     buttonElement.classList.add('correct');
     correctAnswers++;
 
-    // 포인트 메시지 표시
-    showPointsMessage();
+    // 정답 모달 표시
+    showCorrectModal(response.point, response.message);
 
     // 진행률 업데이트
     updateProgress();
-
-    // 화면 클릭 시 즉시 다음 문제로
-    const skipHandler = function () {
-        clearTimeout(autoNextTimeout);
-        document.removeEventListener('click', skipHandler);
-        goToNextQuiz();
-    };
-
-    // 1초 후 자동으로 다음 문제로 이동
-    let autoNextTimeout = setTimeout(() => {
-        document.removeEventListener('click', skipHandler); // 2초가 지나면 클릭 리스너도 제거
-        goToNextQuiz();
-    }, 1000);
-
-    setTimeout(() => {
-        document.addEventListener('click', skipHandler);
-    }, 100); // 현재 클릭 이벤트와 분리
 }
 
 // 오답 처리
-function handleWrongAnswer(buttonElement) {
+function handleWrongAnswer(buttonElement, message) {
     buttonElement.classList.add('wrong');
 
     // 오답 모달 표시
-    showWrongModal();
+    showWrongModal(message);
 
     // 1초 후 원래 상태로
     setTimeout(() => {
@@ -154,16 +137,6 @@ function goToNextQuiz() {
     loadQuiz(currentQuizIndex);
 }
 
-// 포인트 메시지 표시
-function showPointsMessage() {
-    const message = document.getElementById('mission-pointsMessage');
-    message.style.display = 'block';
-
-    setTimeout(() => {
-        message.style.display = 'none';
-    }, 1000);
-}
-
 // 진행률 업데이트
 function updateProgress() {
     const progress = Math.round((correctAnswers / totalQuizCount) * 100);
@@ -171,14 +144,51 @@ function updateProgress() {
     document.getElementById('mission-progressStatus').textContent = progress + '% 달성!';
 }
 
+// 정답 모달 표시
+function showCorrectModal(point, explanation) {
+    const modal = document.getElementById('mission-result-Modal');
+    const pointsMessage = document.getElementById('mission-pointsMessage');
+    const modalTitle = modal.querySelector('.mission-modal-title');
+    const modalMessage = modal.querySelector('.mission-modal-message');
+
+    // 포인트 메시지 표시
+    pointsMessage.textContent = point + ' 포인트 획득하였습니다.';
+    pointsMessage.style.display = 'block';
+
+    modalTitle.textContent = '짝짝짝👏👏👏 정답입니다~';
+    modalMessage.textContent = explanation;
+
+    // 정답 스타일 추가
+    modal.classList.add('correct');
+    modal.classList.add('active');
+}
+
 // 오답 모달 표시
-function showWrongModal() {
-    document.getElementById('mission-wrongModal').classList.add('active');
+function showWrongModal(message) {
+    const modal = document.getElementById('mission-result-Modal');
+    const pointsMessage = document.getElementById('mission-pointsMessage');
+    const modalTitle = modal.querySelector('.mission-modal-title');
+    const modalMessage = modal.querySelector('.mission-modal-message');
+
+    pointsMessage.style.display = 'none';
+    modalTitle.textContent = message; // "다시 한번 생각해 보세요."
+    modalMessage.textContent = '퀴즈를 맞히고 나의 개미 랭크를 높여보세요!';
+
+    // 정답 스타일 제거
+    modal.classList.remove('correct');
+    modal.classList.add('active');
 }
 
 // 모달 닫기
 function closeModal() {
-    document.getElementById('mission-wrongModal').classList.remove('active');
+    const modal = document.getElementById('mission-result-Modal');
+    // 정답 모달인 경우 다음 문제로
+    if (modal.classList.contains('correct')) {
+        closeModalAndNext();
+    } else {
+        // 오답 모달은 그냥 닫기만
+        modal.classList.remove('active');
+    }
 }
 
 // 완료 화면 표시
@@ -227,9 +237,6 @@ function showCompletion() {
             $('#mission-reward-message').text('랭크 정보를 불러오는 데 실패했습니다.');
         }
     });
-
-    // 서버에 완료 전송
-    submitCompletion();
 }
 
 // 헤더(상단바)의 정보 업데이트
@@ -308,11 +315,11 @@ function submitAnswer(quizId, optionId, buttonElement) {
         contentType: 'application/json',
         data: JSON.stringify(requestData),
         dataType: 'json',
-        success: function (isCorrect) {
-            if (isCorrect){
-                handleCorrectAnswer(buttonElement, optionId);
+        success: function (response) {
+            if (response.isCorrect){
+                handleCorrectAnswer(buttonElement, optionId, response);
             } else {
-                handleWrongAnswer(buttonElement);
+                handleWrongAnswer(buttonElement, response.message);
             }
         },
         error: function(xhr, status, error) {
@@ -323,19 +330,18 @@ function submitAnswer(quizId, optionId, buttonElement) {
     })
 }
 
-// 퀴즈 완료 제출
-function submitCompletion() {
-    console.log('Quiz completed:', {
-        totalQuestions: quizData.length,
-        correctAnswers: correctAnswers,
-        score: Math.round((correctAnswers / quizData.length) * 100)
-    });
-}
-
 // 모달 외부 클릭 시 닫기
 window.onclick = function (event) {
-    const modal = document.getElementById('mission-wrongModal');
+    const modal = document.getElementById('mission-result-Modal');
     if (event.target === modal) {
         closeModal();
     }
+}
+
+// 모달 닫고 다음 문제로 이동
+function closeModalAndNext() {
+    const modal = document.getElementById('mission-result-Modal');
+    modal.classList.remove('active');
+    modal.classList.remove('correct');
+    goToNextQuiz();
 }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #162 

---

### 📝 작업 내용
- 사용자가 퀴즈 정답을 맞혔을 때 단순히 포인트 획득 알림만 표시하는 것이 아니라 해당 퀴즈에 대한 설명을 모달로 제공하여 학습 효과를 높였습니다.

[Backend]
- QuizResultDTO: 퀴즈의 정답, 설명, 포인트를 한 번에 조회
- QuizSubmissionResponseDTO: 클라이언트에 정답 여부, 포인트, 메시지 반환
- selectQuizResultByQuizId 추가: 기존 2개 쿼리(정답, 포인트)를 1개로 통합하여 DB 부하 감소
- 정답: isCorrect=true, 포인트, 설명(explanation) 반환
- 오답: isCorrect=false, 포인트=0, "다시 한번 생각해 보세요." 메시지 반환

[Frontend]
- 모달 시스템 통합
  - 기존 오답 전용 모달 → 정답/오답 통합 모달(mission-result-Modal)
  - 모달 구조 개선
- 정답 처리 로직 변경
  - 포인트 획득 알림 + 설명 모달 표시 → 모달 닫으면 다음 문제로 이동

---

### 📷 스크린샷 (선택)
변경전-퀴즈를 맞혔을때
<img width="902" height="290" alt="image" src="https://github.com/user-attachments/assets/3ff7b5b8-fab3-48dc-9774-e03631b48b19" />

변경후-퀴즈를 맞혔을때
<img width="1280" height="712" alt="image" src="https://github.com/user-attachments/assets/4767e386-1260-4ed6-825c-63c0c2019eee" />

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
