### PR TITLE
Feat: 마이페이지 보유 주식, 내 자산에 실시간 현재가 연동

### DIFF
--- a/src/main/java/com/antmillion/kis/constant/KisApiConstant.java
+++ b/src/main/java/com/antmillion/kis/constant/KisApiConstant.java
@@ -12,6 +12,8 @@ public class KisApiConstant {
     public static final String STREAM_MINUTE_PATH = "/uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice";
     public static final String STOCK_VOLUME_RANK = "/uapi/domestic-stock/v1/quotations/volume-rank";
     public static final String DAY_MINUTE_PATH = "/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice";
+    public static final String PRESENT_PRICE = "/uapi/domestic-stock/v1/quotations/inquire-price";
+
     private KisApiConstant() {
         // 인스턴스화 방지
     }

--- a/src/main/java/com/antmillion/kis/dto/CurrentPrice.java
+++ b/src/main/java/com/antmillion/kis/dto/CurrentPrice.java
@@ -1,0 +1,12 @@
+package com.antmillion.kis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CurrentPrice {
+    @JsonProperty("stck_prpr")
+    private String currentPrice;
+}

--- a/src/main/java/com/antmillion/kis/dto/CurrentPriceRequest.java
+++ b/src/main/java/com/antmillion/kis/dto/CurrentPriceRequest.java
@@ -1,0 +1,16 @@
+package com.antmillion.kis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class CurrentPriceRequest {
+    @JsonProperty("FID_COND_MRKT_DIV_CODE")
+    private String marketCode;
+    @JsonProperty("FID_INPUT_ISCD")
+    private String stockCode;
+}

--- a/src/main/java/com/antmillion/kis/dto/KisCurrentPriceResponse.java
+++ b/src/main/java/com/antmillion/kis/dto/KisCurrentPriceResponse.java
@@ -1,0 +1,17 @@
+package com.antmillion.kis.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class KisCurrentPriceResponse {
+    @JsonProperty("rt_cd")
+    private String returnCode;
+    @JsonProperty("msg_cd")
+    private String messageCode;
+    private String msg1;
+
+    private CurrentPrice output;
+}

--- a/src/main/java/com/antmillion/kis/service/KisApiService.java
+++ b/src/main/java/com/antmillion/kis/service/KisApiService.java
@@ -411,4 +411,22 @@ public class KisApiService {
 				.build().toUriString();
 
     }
+
+    public Integer getCurrentPrice(CurrentPriceRequest request) {
+        String token = getKisAccessToken();
+        HttpHeaders headers = createApiHeader(token, "FHKST01010100");
+        URI uri = URI.create(config.getBaseUrl() + KisApiConstant.PRESENT_PRICE);
+        String url = UriComponentsBuilder.fromUri(uri)
+                .queryParam("FID_COND_MRKT_DIV_CODE", request.getMarketCode())
+                .queryParam("FID_INPUT_ISCD", request.getStockCode())
+                .build().toUriString();
+        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+        ResponseEntity<KisCurrentPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisCurrentPriceResponse.class);
+        KisCurrentPriceResponse responseBody = response.getBody();
+        if(responseBody != null && responseBody.getOutput() != null) {
+            return Integer.parseInt(responseBody.getOutput().getCurrentPrice());
+        }
+        throw new RuntimeException("현재가 조회 실패");
+    }
+
 }

--- a/src/main/java/com/antmillion/mypage/service/MyPageServiceImpl.java
+++ b/src/main/java/com/antmillion/mypage/service/MyPageServiceImpl.java
@@ -4,6 +4,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.antmillion.kis.dto.CurrentPriceRequest;
+import com.antmillion.kis.service.KisApiService;
 import org.springframework.stereotype.Service;
 
 import com.antmillion.mypage.mapper.MyPageMapper;
@@ -14,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class MyPageServiceImpl implements MyPageService {
 
     private final MyPageMapper myPageMapper;
+    private final KisApiService kisApiService;
     
     //1. 주식잔고
     @Override
@@ -23,10 +26,15 @@ public class MyPageServiceImpl implements MyPageService {
         
         // 2. 각 종목별로 현재가(고정값) 및 계산 데이터 주입
         for (Map<String, Object> stock : holdings) {
+            String stockCode = stock.get("code").toString();
             long shares = ((Number) stock.get("shares")).longValue();
             long buyPrice = ((Number) stock.get("buyPrice")).longValue();
-            
-            long currentPrice = 80000L; // ✅ 고정값 설정
+            //한투에서 현재가 조회
+            CurrentPriceRequest request = CurrentPriceRequest.builder()
+                    .marketCode("J")
+                    .stockCode(stockCode)
+                    .build();
+            long currentPrice = kisApiService.getCurrentPrice(request);
             long totalValue = currentPrice * shares;
             long profit = totalValue - buyPrice;
             

--- a/src/main/webapp/WEB-INF/views/mypage/mypage.jsp
+++ b/src/main/webapp/WEB-INF/views/mypage/mypage.jsp
@@ -173,10 +173,10 @@
                     <!-- 총 자산 카드 -->
                     <div class="mypage-asset-card">
                         <h3 class="mypage-asset-title">내 자산 총액</h3>
-                        <div class="mypage-asset-amount" id="totalAsset">2,833,000원</div>
+                        <div class="mypage-asset-amount" id="totalAsset"></div>
                         <div class="mypage-asset-profit">
                             <span class="mypage-profit-label">총 평가 손익</span> <span
-                                class="mypage-profit-amount positive" id="totalProfit">276,000원(+27.14%)</span>
+                                class="mypage-profit-amount positive" id="totalProfit"></span>
                         </div>
                     </div>
 
@@ -231,7 +231,11 @@
     <script>
 	    const contextPath = "${cpath}";
 	</script>
+    <!-- SockJS 라이브러리 -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>
 
+    <!-- STOMP 라이브러리 -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
     <script src="${cpath}/resources/js/mypage/mypage.js"></script>
 </body>
 </html>

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -51,7 +51,7 @@ function createMainStockItemHTML(stock, index) {
                 <span class="main-stocklist-name">${stock.hts_kor_isnm}</span>
             </div>
             <div class="main-stocklist-price">${currentPrice}</div>
-            <div class="main-stocklist-change">-</div>
+            <div class="main-stocklist-change">0.00%</div>
             <div class="main-stocklist-sentiment">
                 <div class="main-stocklist-sentiment-bar">
                     <div class="main-stocklist-sentiment-buy" style="width: 50%;"></div>

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -514,7 +514,7 @@ function subscribeStockTopic(stockCode) {
     const topic = '/topic/kis-trade/present' + stockCode;
     const subscription = stompClient.subscribe(topic, function(message) {
         const tradeData = JSON.parse(message.body);
-        console.log('실시간 데이터 수신:', tradeData);
+        // console.log('실시간 데이터 수신:', tradeData);
 
         // 화면 업데이트
         updateStockRealtimePrice(stockCode, tradeData);

--- a/src/main/webapp/resources/js/mypage/mypage.js
+++ b/src/main/webapp/resources/js/mypage/mypage.js
@@ -1,4 +1,178 @@
 // ===========================
+// STOMP 웹소켓 관련 변수 (추가)
+// ===========================
+let stompClient = null;
+let subscribedStockTopics = {}; // 구독한 종목 토픽 저장 {stockCode: subscription}
+let currentHoldingStocks = []; // 현재 보유 중인 종목 정보 (code 포함)
+
+// 계좌 잔고
+let accountBalance = 0;
+
+// ===========================
+// STOMP 연결
+// ===========================
+function connectStompForStockHoldings() {
+    const url = contextPath + '/ws-stomp';
+    const socket = new SockJS(url);
+    stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, function (frame) {
+        console.log('마이페이지 STOMP 연결 성공: ' + frame);
+
+        // 연결 성공 후 보유 종목들 구독
+        if (currentHoldingStocks.length > 0) {
+            subscribeHoldingStocks();
+        }
+    }, function(error) {
+        console.error('마이페이지 STOMP 연결 실패: ' + error);
+        // 5초 후 재연결 시도
+        setTimeout(connectStompForStockHoldings, 5000);
+    });
+}
+
+// ===========================
+// 보유 종목 백엔드 구독 및 STOMP 토픽 구독
+// ===========================
+function subscribeHoldingStocks() {
+    const stockCodes = currentHoldingStocks.map(stock => stock.code);
+
+    if (stockCodes.length === 0) return;
+
+    // 1. 백엔드에 한국투자증권 구독 요청
+    fetch(contextPath + '/api/kis/websocket/subscribe-multiple?trId=H0STCNT0', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(stockCodes)
+    })
+        .then(res => res.json())
+        .then(response => {
+            console.log('마이페이지 백엔드 구독 완료:', response);
+
+            // 2. 프론트엔드 STOMP 토픽 구독
+            stockCodes.forEach(stockCode => {
+                subscribeStockTopicForHolding(stockCode);
+            });
+        })
+        .catch(error => {
+            console.error('마이페이지 백엔드 구독 실패:', error);
+        });
+}
+
+// ===========================
+// 개별 종목 STOMP 토픽 구독
+// ===========================
+function subscribeStockTopicForHolding(stockCode) {
+    if (subscribedStockTopics[stockCode]) {
+        console.log('이미 구독 중:', stockCode);
+        return;
+    }
+
+    const topic = '/topic/kis-trade/present' + stockCode;
+    const subscription = stompClient.subscribe(topic, function(message) {
+        const tradeData = JSON.parse(message.body);
+        console.log('마이페이지 실시간 데이터 수신:', tradeData);
+
+        // 화면 업데이트
+        updateStockHoldingRealtime(stockCode, tradeData);
+    });
+
+    subscribedStockTopics[stockCode] = subscription;
+    console.log('마이페이지 토픽 구독 완료:', topic);
+}
+
+// ===========================
+// 실시간 현재가로 주식 잔고 카드 업데이트
+// ===========================
+function updateStockHoldingRealtime(stockCode, tradeData) {
+    // 해당 종목의 DOM 요소 찾기
+    const stockCard = document.querySelector(`.mypage-stock-card[data-code="${stockCode}"]`);
+    if (!stockCard) return;
+
+    // 현재가 업데이트
+    const currentPrice = Number(tradeData.stckPrpr);
+    const currentPriceElement = stockCard.querySelector('.stock-current-price');
+    if (currentPriceElement) {
+        currentPriceElement.textContent = currentPrice.toLocaleString() + '원';
+    }
+
+    // 해당 종목의 보유 정보 찾기
+    const holdingStock = currentHoldingStocks.find(stock => stock.code === stockCode);
+    if (!holdingStock) return;
+
+    const shares = holdingStock.shares;
+    const buyPrice = holdingStock.buyPrice;
+
+    // 평가금액 = 현재가 × 보유수량
+    const totalValue = currentPrice * shares;
+
+    // 수익금액 = 평가금액 - 매수금액
+    const profit = totalValue - buyPrice;
+
+    // 수익률 = (수익금액 / 매수금액) × 100
+    const profitRate = ((profit / buyPrice) * 100).toFixed(2);
+
+    // currentHoldingStocks 배열의 해당 종목 데이터도 업데이트
+    holdingStock.currentPrice = currentPrice;
+    holdingStock.totalValue = totalValue;
+    holdingStock.profit = profit;
+    holdingStock.profitRate = profitRate;
+
+    // 평가금액 업데이트
+    const totalValueElement = stockCard.querySelector('.stock-total-value');
+    if (totalValueElement) {
+        totalValueElement.textContent = totalValue.toLocaleString() + '원';
+    }
+
+    // 수익금액 및 수익률 업데이트
+    const profitElement = stockCard.querySelector('.mypage-stock-profit');
+    if (profitElement) {
+        const profitClass = profit > 0 ? 'positive' : profit < 0 ? 'negative' : 'neutral';
+        const profitSign = profit > 0 ? '+' : '';
+
+        profitElement.className = `mypage-stock-profit ${profitClass}`;
+        profitElement.textContent = `${profitSign}${profit.toLocaleString()}원(${profitSign}${profitRate}%)`;
+    }
+
+    updateTotalAsset();
+}
+
+// ===========================
+// 모든 구독 해제
+// ===========================
+function unsubscribeAllHoldingStocks() {
+    console.log('마이페이지 구독 해제 시작...');
+
+    // 프론트엔드 STOMP 구독 해제
+    for (let stockCode in subscribedStockTopics) {
+        if (subscribedStockTopics[stockCode]) {
+            subscribedStockTopics[stockCode].unsubscribe();
+            console.log('토픽 구독 해제:', stockCode);
+        }
+    }
+    subscribedStockTopics = {};
+
+    // 백엔드 구독 해제
+    if (currentHoldingStocks.length > 0) {
+        fetch(contextPath + '/api/kis/websocket/unsubscribe-all?trId=H0STCNT0', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            keepalive: true
+        })
+            .then(res => res.json())
+            .then(response => {
+                console.log('마이페이지 백엔드 구독 해제 완료:', response);
+            })
+            .catch(error => {
+                console.error('마이페이지 백엔드 구독 해제 실패:', error);
+            });
+    }
+}
+
+// ===========================
 // BiasType 매핑
 // ===========================
 const biasTypeMap = {
@@ -12,50 +186,6 @@ const biasTypeMap = {
 // 샘플 데이터
 // ===========================
 const sampleData = {
-    // 주식잔고 데이터
-    stockHoldings: [
-        {
-            name: '엔트밀리언',
-            shares: 10,
-            buyPrice: 100000,
-            currentPrice: 5000,
-            profit: -50000,
-            profitRate: -50.00,
-            avgBuyPrice: 10000,
-            totalValue: 50000
-        },
-        {
-            name: '삼성전자',
-            shares: 10,
-            buyPrice: 1017000,
-            currentPrice: 1293000,
-            profit: 276000,
-            profitRate: 27.14,
-            avgBuyPrice: 77000,
-            totalValue: 129300
-        },
-        {
-            name: '삼성전자',
-            shares: 10,
-            buyPrice: 1017000,
-            currentPrice: 1293000,
-            profit: 276000,
-            profitRate: 27.14,
-            avgBuyPrice: 77000,
-            totalValue: 129300
-        },
-        {
-            name: '신한지주',
-            shares: 20,
-            buyPrice: 1540000,
-            currentPrice: 1540000,
-            profit: 0,
-            profitRate: 0,
-            avgBuyPrice: 77000,
-            totalValue: 77000
-        }
-    ],
-    
     // 실현손익 데이터
     realizedProfits: [
         {
@@ -430,12 +560,44 @@ function renderInitialData() {
     renderTradingHistory('all');
 }
 
-// DB에서 주식 잔고 데이터를 가져오는 함수 (새로 추가)
+// DB에서 주식 잔고 데이터를 가져오는 함수 (수정)
 function loadStockHoldings() {
-    fetch(contextPath+'/mypage/api/stock-holdings') // 앞서 만든 컨트롤러 URL
+    // 1. 계좌 정보 조회 (잔고 가져오기)
+    fetch(contextPath + '/mypage/api/account-info')
+        .then(res => res.json())
+        .then(accountData => {
+            // 계좌 잔고 저장
+            accountBalance = accountData.balance || 0;
+            console.log('계좌 잔고:', accountBalance);
+
+            // 2. 주식 잔고 조회
+            return fetch(contextPath + '/mypage/api/stock-holdings');
+        })
         .then(res => res.json())
         .then(data => {
-            renderStockHoldings(data); // 데이터를 받아서 렌더링 함수에 전달
+            if (!data || data.length === 0) {
+                if (stockList) stockList.innerHTML = "<p class='no-data'>보유 중인 주식이 없습니다.</p>";
+                // 잔고만 있는 경우에도 총 자산 업데이트
+                currentHoldingStocks = [];
+                updateTotalAsset();
+                return;
+            }
+
+            // 현재 보유 종목 정보 저장 (code 포함)
+            currentHoldingStocks = data;
+
+            // 화면 렌더링
+            renderStockHoldings(data);
+
+            // 추가: 초기 총 자산 업데이트
+            updateTotalAsset();
+
+            // STOMP 연결 및 구독
+            if (stompClient && stompClient.connected) {
+                subscribeHoldingStocks();
+            } else {
+                connectStompForStockHoldings();
+            }
         })
         .catch(err => {
             console.error("주식 잔고 로드 실패:", err);
@@ -444,9 +606,50 @@ function loadStockHoldings() {
 }
 
 // ===========================
+// 총 자산 계산 및 업데이트
+// ===========================
+function updateTotalAsset() {
+    // 1. 보유 주식의 총 평가금액, 총 매수금액, 총 수익 계산
+    let totalStockValue = 0;  // 보유 주식 총 평가금액
+    let totalBuyPrice = 0;     // 총 매수금액
+    let totalProfit = 0;       // 총 수익금액
+
+    currentHoldingStocks.forEach(stock => {
+        totalStockValue += (stock.totalValue || 0);
+        totalBuyPrice += (stock.buyPrice || 0);
+        totalProfit += (stock.profit || 0);
+    });
+
+    // 2. 내 자산 총액 = 계좌 잔고 + 보유 주식 총 평가금액
+    const totalAsset = accountBalance + totalStockValue;
+
+    // 3. 총 평가손익률 = (총 평가손익 / 총 매수금액) × 100
+    const totalProfitRate = totalBuyPrice > 0
+        ? ((totalProfit / totalBuyPrice) * 100).toFixed(2)
+        : '0.00';
+
+    // 4. DOM 업데이트 - 내 자산 총액
+    const totalAssetElement = document.getElementById('totalAsset');
+    if (totalAssetElement) {
+        totalAssetElement.textContent = totalAsset.toLocaleString() + '원';
+    }
+
+    // 5. DOM 업데이트 - 총 평가 손익
+    const totalProfitElement = document.getElementById('totalProfit');
+    if (totalProfitElement) {
+        const profitClass = totalProfit > 0 ? 'positive' : totalProfit < 0 ? 'negative' : 'neutral';
+        const profitSign = totalProfit > 0 ? '+' : '';
+
+        // 기존 클래스를 유지하면서 positive/negative만 변경
+        totalProfitElement.className = `mypage-profit-amount ${profitClass}`;
+        totalProfitElement.textContent = `${profitSign}${totalProfit.toLocaleString()}원(${profitSign}${totalProfitRate}%)`;
+    }
+}
+
+// ===========================
 // 주식잔고 렌더링 (수정)
 // ===========================
-function renderStockHoldings(holdings) { // ✅ 매개변수 추가
+function renderStockHoldings(holdings) { // 매개변수 추가
     if (!stockList) return;
     
     // 데이터가 없을 때 처리 추가
@@ -461,14 +664,14 @@ function renderStockHoldings(holdings) { // ✅ 매개변수 추가
         const profitSign = stock.profit > 0 ? '+' : '';
         
         return `
-            <div class="mypage-stock-card">
+            <div class="mypage-stock-card" data-code="${stock.code}">
                 <div class="mypage-stock-header">
                     <div>
                         <div class="mypage-stock-name">${stock.name}</div>
                         <div class="mypage-stock-shares">현금 ${stock.shares}주</div>
                     </div>
                     <div class="mypage-stock-profit ${profitClass}">
-                        ${profitSign}${stock.profit.toLocaleString()}원(${profitSign}${stock.profitRate}%)
+                        ${profitSign}${stock.profit.toLocaleString()}원(${profitSign}${stock.profitRate ? stock.profitRate : '0.00'}%)
                     </div>
                 </div>
                 <div class="mypage-stock-details">
@@ -482,11 +685,11 @@ function renderStockHoldings(holdings) { // ✅ 매개변수 추가
                     </div>
                     <div class="mypage-stock-detail-item">
                         <span class="mypage-detail-label">평가 금액</span>
-                        <span class="mypage-detail-value">${stock.totalValue.toLocaleString()}원</span>
+                        <span class="mypage-detail-value stock-total-value">${stock.totalValue.toLocaleString()}원</span>
                     </div>
                     <div class="mypage-stock-detail-item">
                         <span class="mypage-detail-label">현재가</span>
-                        <span class="mypage-detail-value">${stock.currentPrice.toLocaleString()}원</span>
+                        <span class="mypage-detail-value stock-current-price">${stock.currentPrice.toLocaleString()}원</span>
                     </div>
                 </div>
             </div>
@@ -881,3 +1084,20 @@ function formatPercent(num) {
     const sign = num >= 0 ? '+' : '';
     return `${sign}${num}%`;
 }
+
+// ===========================
+// 페이지 떠날 때 구독 해제
+// ===========================
+window.addEventListener('beforeunload', function(e) {
+    unsubscribeAllHoldingStocks();
+
+    if (stompClient !== null && stompClient.connected) {
+        stompClient.disconnect(function() {
+            console.log('마이페이지 STOMP 연결 종료');
+        });
+    }
+});
+
+window.addEventListener('pagehide', function(e) {
+    unsubscribeAllHoldingStocks();
+});

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -83,7 +83,7 @@ function subscribeStockTopic(stockCode) {
     const topic = '/topic/kis-trade/present' + stockCode;
     const subscription = stompClient.subscribe(topic, function(message) {
         const tradeData = JSON.parse(message.body);
-        console.log('실시간 데이터 수신:', tradeData);
+        // console.log('실시간 데이터 수신:', tradeData);
 
         // 화면 업데이트
         updateStockRealtimePrice(stockCode, tradeData);


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #172 

---

### 📝 작업 내용
- mypage의 보유주식 탭과 내 자산 총액, 총 평가 손익 계산에 실시간 현재가를 반영하였습니다.
- 내 자산 총액은 (보유 잔고 + 보유 주식의 수익 총합)으로 계산됩니다.

---

### 📷 스크린샷 (선택)
- 마이페이지 보유주식, 내 자산
<img width="1627" height="578" alt="image" src="https://github.com/user-attachments/assets/219e6a4b-f036-4466-85eb-46c42e813e1d" />

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
