### PR TITLE
Feat: 네이버 뉴스 API 연동 및 뉴스 조회 API 구현

### DIFF
--- a/src/main/java/com/antmillion/config/RestTemplateConfig.java
+++ b/src/main/java/com/antmillion/config/RestTemplateConfig.java
@@ -1,7 +1,9 @@
 package com.antmillion.config;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
@@ -9,6 +11,8 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfig {
 
     @Bean
+    @Primary
+    @Qualifier("kisRestTemplate")
     public RestTemplate kisRestTemplate() {
 
         SimpleClientHttpRequestFactory factory =
@@ -19,5 +23,13 @@ public class RestTemplateConfig {
 
         return new RestTemplate(factory);
     }
-}
 
+    @Bean
+    @Qualifier("naverNewsRestTemplate")
+    public RestTemplate naverNewsRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(5000);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -3,7 +3,6 @@ package com.antmillion.mission.service;
 import com.antmillion.mission.dto.QuizQuestionResponseDTO;
 import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
 import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
-import com.antmillion.naver.dto.NewsSearchResponseDTO;
 import com.antmillion.user.dto.UserRankResponseDTO;
 
 import java.util.List;
@@ -15,5 +14,4 @@ public interface MissionService {
     Long getCurrentUserId();
     boolean isTodayMissionCompleted(Long userId);
     int getTodaySolvedCount(Long userId);
-    NewsSearchResponseDTO getTodayNewsMission();
 }

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -3,6 +3,7 @@ package com.antmillion.mission.service;
 import com.antmillion.mission.dto.QuizQuestionResponseDTO;
 import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
 import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
+import com.antmillion.naver.dto.NewsSearchResponseDTO;
 import com.antmillion.user.dto.UserRankResponseDTO;
 
 import java.util.List;
@@ -14,4 +15,5 @@ public interface MissionService {
     Long getCurrentUserId();
     boolean isTodayMissionCompleted(Long userId);
     int getTodaySolvedCount(Long userId);
+    NewsSearchResponseDTO getTodayNewsMission();
 }

--- a/src/main/java/com/antmillion/naver/config/NaverNewsApiConfig.java
+++ b/src/main/java/com/antmillion/naver/config/NaverNewsApiConfig.java
@@ -1,0 +1,20 @@
+package com.antmillion.naver.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Getter
+@PropertySource("classpath:naverNewsApi.properties")
+@Configuration
+public class NaverNewsApiConfig {
+    @Value("${naverNews.api.client-id}")
+    private String clientId;
+
+    @Value("${naverNews.api.client-secret}")
+    private String clientSecret;
+
+    @Value("${naverNews.api.news-url}")
+    private String newsUrl;
+}

--- a/src/main/java/com/antmillion/naver/controller/NaverNewsController.java
+++ b/src/main/java/com/antmillion/naver/controller/NaverNewsController.java
@@ -1,0 +1,19 @@
+package com.antmillion.naver.controller;
+
+import com.antmillion.naver.dto.NewsSearchResponseDTO;
+import com.antmillion.naver.service.NaverNewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/news")
+public class NaverNewsController {
+
+    private final NaverNewsService naverNewsService;
+
+    @GetMapping
+    public NewsSearchResponseDTO getNews() {
+        return naverNewsService.getNews();
+    }
+}

--- a/src/main/java/com/antmillion/naver/dto/NaverNewsItemDTO.java
+++ b/src/main/java/com/antmillion/naver/dto/NaverNewsItemDTO.java
@@ -1,0 +1,14 @@
+package com.antmillion.naver.dto;
+
+import lombok.*;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NaverNewsItemDTO {
+    private String title;
+    private String link;
+    private String description;
+    private String pubDate;
+}

--- a/src/main/java/com/antmillion/naver/dto/NaverNewsSearchResponseDTO.java
+++ b/src/main/java/com/antmillion/naver/dto/NaverNewsSearchResponseDTO.java
@@ -1,0 +1,14 @@
+package com.antmillion.naver.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NaverNewsSearchResponseDTO {
+    private int total;
+    private List<NaverNewsItemDTO> items;
+}

--- a/src/main/java/com/antmillion/naver/dto/NewsSearchResponseDTO.java
+++ b/src/main/java/com/antmillion/naver/dto/NewsSearchResponseDTO.java
@@ -1,0 +1,22 @@
+package com.antmillion.naver.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NewsSearchResponseDTO {
+    private int totalCount;
+    private List<NaverNewsItemDTO> articles;
+
+    public void assignTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public void assignArticles(List<NaverNewsItemDTO> articles) {
+        this.articles = articles;
+    }
+}

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -1,0 +1,83 @@
+package com.antmillion.naver.service;
+
+import com.antmillion.naver.config.NaverNewsApiConfig;
+import com.antmillion.naver.dto.NaverNewsItemDTO;
+import com.antmillion.naver.dto.NaverNewsSearchResponseDTO;
+import com.antmillion.naver.dto.NewsSearchResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NaverNewsService {
+
+    @Qualifier("naverNewsRestTemplate")
+    private final RestTemplate restTemplate;
+    private final NaverNewsApiConfig naverNewsApiConfig;
+
+    // 캐싱을 위한 변수들
+    private NewsSearchResponseDTO cachedNews;
+    private LocalDateTime lastFetchTime;
+    private static final String FIXED_KEYWORD = "증권";
+
+    public NewsSearchResponseDTO getNews() {
+        if (cachedNews == null || lastFetchTime == null || lastFetchTime.isBefore(LocalDateTime.now().minusHours(24))) {
+            cachedNews = fetchFromNaverNewsApi(FIXED_KEYWORD);
+        }
+        return cachedNews;
+    }
+
+    public NewsSearchResponseDTO fetchFromNaverNewsApi(String keyword) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(naverNewsApiConfig.getNewsUrl())
+                .queryParam("query", keyword)
+                .queryParam("display", 50)
+                .queryParam("start", 1)
+                .queryParam("sort", "date")
+                .build()
+                .encode()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", naverNewsApiConfig.getClientId());
+        headers.set("X-Naver-Client-Secret", naverNewsApiConfig.getClientSecret());
+
+        ResponseEntity<NaverNewsSearchResponseDTO> response =
+                restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        new HttpEntity<>(headers),
+                        NaverNewsSearchResponseDTO.class
+                );
+
+        NaverNewsSearchResponseDTO naverNewsResponse = response.getBody();
+        if (naverNewsResponse == null) {
+            throw new IllegalStateException("네이버 뉴스 API 응답이 없습니다.");
+        }
+
+        // 네이버 뉴스만 필터
+        List<NaverNewsItemDTO> filteredItems =
+                naverNewsResponse.getItems().stream()
+                        .filter(item ->
+                                item.getLink() != null &&
+                                        item.getLink().startsWith("https://n.news.naver.com")
+                        )
+                        .limit(5)
+                        .collect(Collectors.toList());
+
+        NewsSearchResponseDTO newsSearchResponse = new NewsSearchResponseDTO();
+        newsSearchResponse.assignTotalCount(filteredItems.size());
+        newsSearchResponse.assignArticles(filteredItems);
+
+        return newsSearchResponse;
+    }
+}

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -70,7 +70,8 @@ public class NaverNewsService {
                 naverNewsResponse.getItems().stream()
                         .filter(item ->
                                 item.getLink() != null &&
-                                        item.getLink().startsWith("https://n.news.naver.com")
+                                        item.getLink().startsWith("https://n.news.naver.com") &&
+                                        item.getLink().contains("sid=101")
                         )
                         .limit(5)
                         .collect(Collectors.toList());

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -32,6 +32,7 @@ public class NaverNewsService {
     public NewsSearchResponseDTO getNews() {
         if (cachedNews == null || lastFetchTime == null || lastFetchTime.isBefore(LocalDateTime.now().minusHours(24))) {
             cachedNews = fetchFromNaverNewsApi(FIXED_KEYWORD);
+            lastFetchTime = LocalDateTime.now();
         }
         return cachedNews;
     }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #175 

---

### 📝 작업 내용
- 뉴스 페이지에서 보여줄 네이버 (증권)뉴스 API 연동 및 뉴스 조회 API를 구현했습니다.
---

### 📷 스크린샷 (선택)
/api/news 를 통해 헤드라인 5건 조회 가능합니다. 하루 단위로 캐싱됩니다.
naverNewsApi.properties 파일은 슬랙에 올려놓았습니다.
<img width="1280" height="582" alt="image" src="https://github.com/user-attachments/assets/b31703b3-42a9-4464-b922-ca5ceb4c9a2c" />

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
