### PR TITLE
Refactor: 한국투자증권 웹소켓 tr_id 조정

### DIFF
--- a/src/main/java/com/antmillion/kis/constant/KisWebSocketTrId.java
+++ b/src/main/java/com/antmillion/kis/constant/KisWebSocketTrId.java
@@ -1,0 +1,73 @@
+package com.antmillion.kis.constant;
+
+import lombok.Getter;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+public enum KisWebSocketTrId {
+    // KRX (정규장 09:00 ~ 15:30)
+    KRX_PRESENT("H0STCNT0", "실시간체결가-KRX"),
+    KRX_ASK_BID("H0STASP0", "실시간호가-KRX"),
+    // 통합 (시간외 15:30 ~ 20:00)
+    UNIFIED_PRESENT("H0UNCNT0", "실시간체결가-통합"),
+    UNIFIED_ASK_BID("H0UNASP0", "실시간호가-통합");
+
+    @Getter
+    private final String trId;
+    @Getter
+    private final String description;
+
+    KisWebSocketTrId(String trId, String description) {
+        this.trId = trId;
+        this.description = description;
+    }
+
+    /**
+     * 현재 시간에 맞는 실시간 체결가 tr_id 반환
+     */
+    public static String getCurrentPresentTrId() {
+        LocalTime now = LocalTime.now(ZoneId.of("Asia/Seoul"));
+        LocalTime marketClose = LocalTime.of(15, 30);
+
+        if (now.isBefore(marketClose)) {
+            return KRX_PRESENT.getTrId(); // H0STCNT0
+        } else {
+            return UNIFIED_PRESENT.getTrId(); // H0UNCNT0
+        }
+    }
+
+    /**
+     * 현재 시간에 맞는 실시간 호가 tr_id 반환
+     */
+    public static String getCurrentAskBidTrId() {
+        LocalTime now = LocalTime.now(ZoneId.of("Asia/Seoul"));
+        LocalTime marketClose = LocalTime.of(15, 30);
+
+        if (now.isBefore(marketClose)) {
+            return KRX_ASK_BID.getTrId(); // H0STASP0
+        } else {
+            return UNIFIED_ASK_BID.getTrId(); // H0UNASP0
+        }
+    }
+
+    /**
+     * tr_id로부터 토픽 경로 생성
+     */
+    public static String getTopicPath(String trId, String stockCode) {
+        if (trId.equals(KRX_PRESENT.getTrId()) || trId.equals(UNIFIED_PRESENT.getTrId())) {
+            return "/topic/kis-trade/present" + stockCode;
+        } else if (trId.equals(KRX_ASK_BID.getTrId()) || trId.equals(UNIFIED_ASK_BID.getTrId())) {
+            return "/topic/kis-trade/ask-bid" + stockCode;
+        }
+        throw new IllegalArgumentException("Unknown tr_id: " + trId);
+    }
+
+    public static boolean isPresentPriceTrId(String trId) {
+        return trId.equals(KRX_PRESENT.getTrId()) || trId.equals(UNIFIED_PRESENT.getTrId());
+    }
+
+    public static boolean isAskBidTrId(String trId) {
+        return trId.equals(KRX_ASK_BID.getTrId()) ||  trId.equals(UNIFIED_ASK_BID.getTrId());
+    }
+}

--- a/src/main/java/com/antmillion/kis/controller/KisWebSocketController.java
+++ b/src/main/java/com/antmillion/kis/controller/KisWebSocketController.java
@@ -1,5 +1,6 @@
 package com.antmillion.kis.controller;
 
+import com.antmillion.kis.constant.KisWebSocketTrId;
 import com.antmillion.kis.manager.KisWebSocketManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -7,7 +8,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 @RestController
 @RequestMapping("/api/kis/websocket")
@@ -15,33 +15,6 @@ import java.util.Set;
 public class KisWebSocketController {
 
     private final KisWebSocketManager kisWebSocketManager;
-
-    /**
-     * 단일 종목 구독
-     * POST /api/kis/websocket/subscribe/005930
-     */
-    @PostMapping("/subscribe/{stockCode}")
-    public Map<String, Object> subscribe(
-            @PathVariable("stockCode") String stockCode,
-            @RequestParam("trId") String trId) {
-        Map<String, Object> response = new HashMap<>();
-        try {
-            kisWebSocketManager.subscribe(stockCode, trId);
-            Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
-                stocks = kisWebSocketManager.getPresentSubscribedStocks();
-            } else {
-                stocks = kisWebSocketManager.getAskBidSubscribedStocks();
-            }
-            response.put("success", true);
-            response.put("stockCode", stockCode);
-            response.put("subscribedStocks", stocks);
-        } catch (Exception e) {
-            response.put("success", false);
-            response.put("message", "구독 실패: " + e.getMessage());
-        }
-        return response;
-    }
 
     /**
      * 여러 종목 한번에 구독
@@ -55,49 +28,20 @@ public class KisWebSocketController {
             ) {
         Map<String, Object> response = new HashMap<>();
         try {
-            for (String stockCode : stockCodes) {
-                kisWebSocketManager.subscribe(stockCode, trId);
-            }
-            Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
-                stocks = kisWebSocketManager.getPresentSubscribedStocks();
+            String actualTrId;
+            if (trId.contains("CNT")) {
+                actualTrId = KisWebSocketTrId.getCurrentPresentTrId();
             } else {
-                stocks = kisWebSocketManager.getAskBidSubscribedStocks();
+                actualTrId = KisWebSocketTrId.getCurrentAskBidTrId();
+            }
+            for (String stockCode : stockCodes) {
+                kisWebSocketManager.subscribe(stockCode, actualTrId);
             }
             response.put("success", true);
             response.put("count", stockCodes.size());
-            response.put("subscribedStocks", stocks);
         } catch (Exception e) {
             response.put("success", false);
             response.put("message", "구독 실패: " + e.getMessage());
-        }
-        return response;
-    }
-
-    /**
-     * 단일 종목 구독 해제
-     * DELETE /api/kis/websocket/unsubscribe/005930
-     */
-    @PostMapping("/unsubscribe/{stockCode}")
-    public Map<String, Object> unsubscribe(
-            @PathVariable String stockCode,
-            @RequestParam("trId") String  trId
-            ) {
-        Map<String, Object> response = new HashMap<>();
-        try {
-            kisWebSocketManager.unsubscribe(stockCode, trId);
-            Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
-                stocks = kisWebSocketManager.getPresentSubscribedStocks();
-            } else {
-                stocks = kisWebSocketManager.getAskBidSubscribedStocks();
-            }
-            response.put("success", true);
-            response.put("message", "구독 해제: " + stockCode);
-            response.put("subscribedStocks", stocks);
-        } catch (Exception e) {
-            response.put("success", false);
-            response.put("message", "구독 해제 실패: " + e.getMessage());
         }
         return response;
     }
@@ -110,37 +54,19 @@ public class KisWebSocketController {
     public Map<String, Object> unsubscribeAll(@RequestParam("trId") String trId) {
         Map<String, Object> response = new HashMap<>();
         try {
-            kisWebSocketManager.unsubscribeAll(trId);
-            Set<String> stocks;
-            if (trId.equals("H0UNCNT0")) {
-                stocks = kisWebSocketManager.getPresentSubscribedStocks();
+            String actualTrId;
+            if (trId.contains("CNT")) {
+                actualTrId = KisWebSocketTrId.getCurrentPresentTrId();
             } else {
-                stocks = kisWebSocketManager.getAskBidSubscribedStocks();
+                actualTrId = KisWebSocketTrId.getCurrentAskBidTrId();
             }
+            kisWebSocketManager.unsubscribeAll(actualTrId);
             response.put("success", true);
             response.put("message", "전체 구독 해제 완료");
-            response.put("subscribedStocks", stocks);
         } catch (Exception e) {
             response.put("success", false);
             response.put("message", "전체 구독 해제 실패: " + e.getMessage());
         }
-        return response;
-    }
-
-    /**
-     * 현재 구독 중인 종목 목록 조회
-     * GET /api/kis/websocket/subscribed
-     */
-    @GetMapping("/subscribed")
-    public Map<String, Object> getSubscribedStocks(
-            @RequestParam("trId") String trId
-    ) {
-        Map<String, Object> response = new HashMap<>();
-        Set<String> subscribed = trId.equals("H0UNCNT0") ?
-                kisWebSocketManager.getPresentSubscribedStocks()
-                : kisWebSocketManager.getAskBidSubscribedStocks();
-        response.put("count", subscribed.size());
-        response.put("stocks", subscribed);
         return response;
     }
 

--- a/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
+++ b/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
@@ -13,6 +13,9 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import com.antmillion.kis.manager.KisWebSocketManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static com.antmillion.kis.constant.KisWebSocketTrId.isAskBidTrId;
+import static com.antmillion.kis.constant.KisWebSocketTrId.isPresentPriceTrId;
+
 /**
  * 웹소켓 통로를 통해 데이터(메시지) 처리
  * 
@@ -69,9 +72,10 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         // 3. 실시간 실무 데이터 처리 (문자열 파싱)
         try {
             String[] parts = payload.split("\\|");
-            if ("H0UNCNT0".equals(parts[1])) {
-            	String[] data = parts[3].split("\\^");
-            	// [0], [2], [4], [5], [22]
+            String trId = parts[1];
+            if (isPresentPriceTrId(trId)) {
+                String[] data = parts[3].split("\\^");
+                // [0], [2], [4], [5], [22]
                 Map<String, String> tradeData = new HashMap<>();
                 tradeData.put("mkscShrnIscd", data[0]); // 종목코드
                 tradeData.put("stckPrpr", data[2]);     // 현재가
@@ -79,12 +83,12 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
                 tradeData.put("prdyVrss", data[4]);	// 전일 대비
                 tradeData.put("prdyCtrt", data[5]);     // 대비율
                 tradeData.put("shnuRate", data[22]);     // 매수 비율
-                
+
                 String stockCode = data[0];
                 // STOMP 전송
                 messagingTemplate.convertAndSend("/topic/kis-trade/present" + stockCode, tradeData); // 실시간 체결가
                 System.out.println("체결가 수신: " + tradeData);
-            } else if ("H0UNASP0".equals(parts[1])) {
+            } else if (isAskBidTrId(trId)) {
                 String[] data = parts[3].split("\\^");
                 Map<String, String> askBidData = new HashMap<>();
                 askBidData.put("mkscShrnIscd", data[0]); // 종목코드

--- a/src/main/java/com/antmillion/kis/manager/KisWebSocketManager.java
+++ b/src/main/java/com/antmillion/kis/manager/KisWebSocketManager.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.Setter;
 
+import static com.antmillion.kis.constant.KisWebSocketTrId.isPresentPriceTrId;
+
 /**
  * 웹소켓 Connection 처리
  * 
@@ -40,10 +42,8 @@ public class KisWebSocketManager {
     private boolean isConnected = false; // 연결 상태 저장
     private String approvalKey;
 
-    @Getter
     private final Set<String> presentSubscribedStocks = ConcurrentHashMap.newKeySet();
 
-    @Getter
     private final Set<String> askBidSubscribedStocks = ConcurrentHashMap.newKeySet();
 
     public KisWebSocketManager(KisApiService kisApiService, SimpMessagingTemplate messagingTemplate) {
@@ -100,18 +100,11 @@ public class KisWebSocketManager {
     
     // 세션 관리용
     public synchronized void subscribe(String stockCode, String trId) {
+        Set<String> targetSet = isPresentPriceTrId(trId) ?  presentSubscribedStocks : askBidSubscribedStocks;
         // 중복 구독 방지
-        if (trId.equals("H0UNCNT0")) {
-            if (presentSubscribedStocks.contains(stockCode)) {
-                System.out.println("이미 체결가 구독 중인 종목: " + stockCode);
-                return;
-            }
-
-        } else {
-            if (askBidSubscribedStocks.contains(stockCode)) {
-                System.out.println("이미 호가 구독 중인 종목: " + stockCode);
-                return;
-            }
+        if (targetSet.contains(stockCode)) {
+            System.out.println("이미 " + trId + " 구독 중인 종목: " + stockCode);
+            return;
         }
 
         if (session == null || !session.isOpen()) {
@@ -120,60 +113,38 @@ public class KisWebSocketManager {
         }
         
         this.sendSubscribeMessage(this.session, stockCode, "1", trId);  // 실제 구독 메시지 전송
-
-        if (trId.equals("H0UNCNT0")) {
-            presentSubscribedStocks.add(stockCode);
-        } else {
-            askBidSubscribedStocks.add(stockCode);
-        }
+        targetSet.add(stockCode);
 
         System.out.println("구독 완료: " + stockCode + " trId: " + trId);
     }
 
     // 🆕 구독 해제 메소드
     public synchronized void unsubscribe(String stockCode, String trId) {
-        if (trId.equals("H0UNCNT0")) {
-            if (!presentSubscribedStocks.contains(stockCode)) {
-                System.out.println("체결가 구독 중이 아닌 종목: " + stockCode);
-                return;
-            }
-        } else {
-            if (!askBidSubscribedStocks.contains(stockCode)) {
-                System.out.println("호가 구독 중이 아닌 종목: " + stockCode);
-                return;
-            }
+        Set<String> targetSet = isPresentPriceTrId(trId) ?  presentSubscribedStocks : askBidSubscribedStocks;
+        if (!targetSet.contains(stockCode)) {
+            System.out.println(trId + " 구독 중이 아닌 종목: " + stockCode);
+            return;
         }
 
         if (this.session != null && this.session.isOpen()) {
             sendSubscribeMessage(this.session, stockCode, "2", trId);  // "2" = 구독 해제
-            if (trId.equals("H0UNCNT0")) {
-                presentSubscribedStocks.remove(stockCode);
-            } else {
-                askBidSubscribedStocks.remove(stockCode);
-            }
+            targetSet.remove(stockCode);
             System.out.println("구독 해제: " + stockCode + " trId: " + trId);
         }
     }
 
     // 🆕 전체 구독 해제
     public synchronized void unsubscribeAll(String trId) {
-        if (trId.equals("H0UNCNT0")) {
-            if (presentSubscribedStocks.isEmpty()) {
-                System.out.println("체결가 구독 중인 종목이 없습니다.");
-                return;
-            }
-        } else {
-            if (askBidSubscribedStocks.isEmpty()) {
-                System.out.println("호가 구독 중인 종목이 없습니다.");
-                return;
-            }
+        Set<String> targetSet = isPresentPriceTrId(trId) ?  presentSubscribedStocks : askBidSubscribedStocks;
+        if (targetSet.isEmpty()) {
+            System.out.println(trId + " 구독 중인 종목이 없습니다.");
+            return;
         }
 
         System.out.println(trId + " 전체 구독 해제 시작");
-        Set<String> subscribedStocks = trId.equals("H0UNCNT0") ? presentSubscribedStocks : askBidSubscribedStocks;
         // 복사본으로 반복 (ConcurrentModificationException 방지)
         Set<String> stocksToUnsubscribe = ConcurrentHashMap.newKeySet();
-        stocksToUnsubscribe.addAll(subscribedStocks);
+        stocksToUnsubscribe.addAll(targetSet);
 
         for (String stockCode : stocksToUnsubscribe) {
             unsubscribe(stockCode, trId);
@@ -202,7 +173,9 @@ public class KisWebSocketManager {
         try {
             String json = objectMapper.writeValueAsString(request);
             session.sendMessage(new TextMessage(json));
-            System.out.println((trId.equals("H0UNCNT0") ? "현재가 " : "호가 ") + (trType.equals("1") ? "구독" : "해제") + " 요청 전송: " + stockCode);
+
+            String dataType = isPresentPriceTrId(trId) ? "체결가" : "호가";
+            System.out.println(dataType + (trType.equals("1") ? "구독" : "해제") + " 요청 전송: " + stockCode);
         } catch (IOException e) {
             System.err.println("메시지 전송 실패: " + e.getMessage());
         }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #185 

---

### 📝 작업 내용
- tr_id를 enum으로 공통으로 관리하여, 15시 30분 이전까지는 KRX tr_id를, 이후에는 KRX+NXT 통합 tr_id를 사용하도록 하였습니다. 요청 시에 반영되는거라 아직 완전 자동화는 아닙니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
