### PR TITLE
Feat: 종목 상세페이지 매수·매도 주문 기능 구현 (지정가/시장가, 주문 확인 팝업)

### DIFF
--- a/src/main/java/com/antmillion/stock/controller/AccountBalanceController.java
+++ b/src/main/java/com/antmillion/stock/controller/AccountBalanceController.java
@@ -1,0 +1,99 @@
+package com.antmillion.stock.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.antmillion.auth.mapper.AccountMapper;
+import com.antmillion.stock.mapper.AssetMapper;
+import com.antmillion.user.dto.AccountDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/account")
+public class AccountBalanceController {
+
+    private final AccountMapper accountMapper;
+    private final AssetMapper assetMapper;
+
+    /**
+     * 현재 계좌 잔액 조회 API
+     */
+    @GetMapping("/balance")
+    public ResponseEntity<Map<String, Object>> getBalance(HttpSession session) {
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            // ===== 테스트용: 세션 없으면 accountId = 1 사용 =====
+            AccountDTO accountDTO = (AccountDTO) session.getAttribute("account");
+            Long accountId = (accountDTO != null) ? accountDTO.getAccountId() : 1L;
+            
+            log.info("잔액 조회 - accountId: {}", accountId);
+            
+            // 계좌 정보 조회
+            AccountDTO account = accountMapper.selectByAccountId(accountId);
+            
+            if (account != null) {
+                response.put("success", true);
+                response.put("balance", account.getBalance());
+                response.put("accountNumber", account.getAccountNumber());
+                log.info("잔액 조회 성공: {} 원", account.getBalance());
+            } else {
+                response.put("success", false);
+                response.put("message", "계좌를 찾을 수 없습니다.");
+            }
+            
+        } catch (Exception e) {
+            log.error("잔액 조회 오류", e);
+            response.put("success", false);
+            response.put("message", "잔액 조회 중 오류가 발생했습니다: " + e.getMessage());
+        }
+        
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 특정 종목의 보유 수량 조회 API
+     */
+    @GetMapping("/holdings")
+    public ResponseEntity<Map<String, Object>> getHoldings(
+            @RequestParam String stockCode,
+            HttpSession session) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            // ===== 테스트용: 세션 없으면 accountId = 1 사용 =====
+            AccountDTO accountDTO = (AccountDTO) session.getAttribute("account");
+            Long accountId = (accountDTO != null) ? accountDTO.getAccountId() : 1L;
+            
+            log.info("보유 수량 조회 - accountId: {}, stockCode: {}", accountId, stockCode);
+            
+            // 보유 수량 조회 (SUM으로 합산)
+            Integer quantity = assetMapper.getQuantityByAccountAndStock(accountId, stockCode);
+            
+            response.put("success", true);
+            response.put("quantity", quantity != null ? quantity : 0);
+            log.info("보유 수량 조회 성공: {} 주", quantity);
+            
+        } catch (Exception e) {
+            log.error("보유 수량 조회 오류", e);
+            response.put("success", false);
+            response.put("message", "보유 수량 조회 중 오류가 발생했습니다: " + e.getMessage());
+            response.put("quantity", 0);
+        }
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/antmillion/stock/controller/StockOrderController.java
+++ b/src/main/java/com/antmillion/stock/controller/StockOrderController.java
@@ -1,0 +1,78 @@
+package com.antmillion.stock.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.antmillion.stock.service.StockOrderService;
+import com.antmillion.user.dto.AccountDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/stock")
+public class StockOrderController {
+
+    private final StockOrderService stockOrderService;
+
+    /**
+     * 주식 주문 API
+     */
+    @PostMapping("/order")
+    public ResponseEntity<Map<String, Object>> createOrder(
+            @RequestBody Map<String, Object> orderRequest,
+            HttpSession session) {
+        
+        Map<String, Object> response = new HashMap<>();
+        
+        try {
+            // ===== 테스트용: 세션 없으면 accountId = 1 사용 =====
+            AccountDTO accountDTO = (AccountDTO) session.getAttribute("account");
+            Long accountId = (accountDTO != null) ? accountDTO.getAccountId() : 1L;
+            
+            String stockCode = (String) orderRequest.get("stockCode");
+            String transactionType = (String) orderRequest.get("transactionType");
+            String orderType = (String) orderRequest.get("orderType");
+            Integer quantity = (Integer) orderRequest.get("quantity");
+            Integer orderPrice = (Integer) orderRequest.get("orderPrice");
+            
+            log.info("주문 요청 - accountId: {}, stockCode: {}, type: {}, qty: {}, price: {}", 
+                    accountId, stockCode, transactionType, quantity, orderPrice);
+            
+            // 주문 처리
+            boolean result = stockOrderService.createOrder(
+                    accountId, stockCode, transactionType, orderType, quantity, orderPrice);
+            
+            if (result) {
+                response.put("success", true);
+                response.put("message", "주문이 완료되었습니다.");
+                log.info("주문 성공");
+            } else {
+                response.put("success", false);
+                response.put("message", "주문 처리 중 오류가 발생했습니다.");
+                log.warn("주문 실패");
+            }
+            
+        } catch (IllegalArgumentException e) {
+            log.error("주문 검증 실패: {}", e.getMessage());
+            response.put("success", false);
+            response.put("message", e.getMessage());
+        } catch (Exception e) {
+            log.error("주문 오류", e);
+            response.put("success", false);
+            response.put("message", "주문 중 오류가 발생했습니다: " + e.getMessage());
+        }
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/antmillion/stock/dto/StockOrderDTO.java
+++ b/src/main/java/com/antmillion/stock/dto/StockOrderDTO.java
@@ -2,25 +2,18 @@ package com.antmillion.stock.dto;
 
 import java.time.LocalDateTime;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.Data;
 
-@Getter@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@ToString
+@Data
 public class StockOrderDTO {
-	private Long orderId;
+    private Long orderId;
     private Long accountId;
     private String stockCode;
-    private String transactionType;
-    private String orderType;
+    private String transactionType; 
+    private String orderType; 
     private Integer quantity;
-    private Long orderPrice;
-    private String status;
+    private Integer orderPrice;
+    private String status; 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/antmillion/stock/mapper/AssetMapper.java
+++ b/src/main/java/com/antmillion/stock/mapper/AssetMapper.java
@@ -1,0 +1,47 @@
+package com.antmillion.stock.mapper;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
+
+@Mapper
+public interface AssetMapper {
+    
+    /**
+     * 특정 계좌의 특정 종목 보유 수량 조회 (합산)
+     */
+    @Select("SELECT COALESCE(SUM(quantity), 0) " +
+            "FROM asset " +
+            "WHERE account_id = #{accountId} AND stock_code = #{stockCode}")
+    Integer getQuantityByAccountAndStock(@Param("accountId") Long accountId, 
+                                         @Param("stockCode") String stockCode);
+    
+    /**
+     * 자산 추가 (신규 매수)
+     */
+    @Insert("INSERT INTO asset (account_id, stock_code, quantity, avg_price, purchase_amount, updated_at) " +
+            "VALUES (#{accountId}, #{stockCode}, #{quantity}, #{avgPrice}, #{purchaseAmount}, NOW())")
+    int insertAsset(@Param("accountId") Long accountId,
+                    @Param("stockCode") String stockCode,
+                    @Param("quantity") Integer quantity,
+                    @Param("avgPrice") Integer avgPrice,
+                    @Param("purchaseAmount") Long purchaseAmount);
+    
+    /**
+     * 자산 수량 감소 (매도)
+     * 가장 오래된 자산부터 차감
+     */
+    @Update("UPDATE asset " +
+            "SET quantity = quantity - #{quantity}, " +
+            "    updated_at = NOW() " +
+            "WHERE account_id = #{accountId} " +
+            "AND stock_code = #{stockCode} " +
+            "AND quantity > 0 " +
+            "ORDER BY updated_at ASC " +
+            "LIMIT 1")
+    int decreaseAssetQuantity(@Param("accountId") Long accountId,
+                              @Param("stockCode") String stockCode,
+                              @Param("quantity") Integer quantity);
+}

--- a/src/main/java/com/antmillion/stock/mapper/StockOrderMapper.java
+++ b/src/main/java/com/antmillion/stock/mapper/StockOrderMapper.java
@@ -1,0 +1,19 @@
+package com.antmillion.stock.mapper;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+
+import com.antmillion.stock.dto.StockOrderDTO;
+
+@Mapper
+public interface StockOrderMapper {
+
+    /**
+     * 주문 생성
+     */
+    @Insert("INSERT INTO stock_order (account_id, stock_code, transaction_type, order_type, quantity, order_price, status, created_at, updated_at) " +
+            "VALUES (#{accountId}, #{stockCode}, #{transactionType}, #{orderType}, #{quantity}, #{orderPrice}, #{status}, #{createdAt}, #{updatedAt})")
+    @Options(useGeneratedKeys = true, keyProperty = "orderId")
+    int insertOrder(StockOrderDTO order);
+}

--- a/src/main/java/com/antmillion/stock/service/StockOrderService.java
+++ b/src/main/java/com/antmillion/stock/service/StockOrderService.java
@@ -1,0 +1,98 @@
+package com.antmillion.stock.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.antmillion.auth.mapper.AccountMapper;
+import com.antmillion.stock.dto.StockOrderDTO;
+import com.antmillion.stock.mapper.AssetMapper;
+import com.antmillion.stock.mapper.StockOrderMapper;
+import com.antmillion.user.dto.AccountDTO;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockOrderService {
+
+    private final StockOrderMapper stockOrderMapper;
+    private final AccountMapper accountMapper;
+    private final AssetMapper assetMapper;
+
+    @Transactional
+    public boolean createOrder(Long accountId, String stockCode, String transactionType, 
+                               String orderType, Integer quantity, Integer orderPrice) {
+        
+        // 1. 계좌 정보 조회
+        AccountDTO account = accountMapper.selectByAccountId(accountId);
+        if (account == null) {
+            throw new IllegalArgumentException("계좌를 찾을 수 없습니다.");
+        }
+        
+        long totalPrice = (long) orderPrice * quantity;
+        
+        // 2. 매수/매도 검증
+        if ("BUY".equals(transactionType)) {
+            // 매수: 잔액 확인
+            if (account.getBalance() < totalPrice) {
+                throw new IllegalArgumentException("잔액이 부족합니다.");
+            }
+        } else if ("SELL".equals(transactionType)) {
+            // 매도: 보유 수량 확인
+            Integer ownedQuantity = assetMapper.getQuantityByAccountAndStock(accountId, stockCode);
+            if (ownedQuantity == null || ownedQuantity < quantity) {
+                throw new IllegalArgumentException("보유 수량이 부족합니다.");
+            }
+        }
+        
+        // 3. 주문 생성
+        StockOrderDTO order = new StockOrderDTO();
+        order.setAccountId(accountId);
+        order.setStockCode(stockCode);
+        order.setTransactionType(transactionType);
+        order.setOrderType(orderType);
+        order.setQuantity(quantity);
+        order.setOrderPrice(orderPrice);
+        order.setStatus("COMPLETED");
+        order.setCreatedAt(LocalDateTime.now());
+        order.setUpdatedAt(LocalDateTime.now());
+        
+        int result = stockOrderMapper.insertOrder(order);
+        log.info("주문 저장 완료 - orderId: {}", order.getOrderId());
+        
+        // 4. 잔액 및 자산 업데이트
+        if ("BUY".equals(transactionType)) {
+            // 매수: 잔액 차감
+            long newBalance = account.getBalance() - totalPrice;
+            accountMapper.updateBalance(accountId, newBalance);
+            log.info("잔액 차감: {} → {}", account.getBalance(), newBalance);
+            
+            // 자산 추가
+            assetMapper.insertAsset(accountId, stockCode, quantity, orderPrice, totalPrice);
+            log.info("자산 추가: {} 종목 {} 주 매수", stockCode, quantity);
+            
+        } else if ("SELL".equals(transactionType)) {
+            // 매도: 잔액 증가
+            long newBalance = account.getBalance() + totalPrice;
+            accountMapper.updateBalance(accountId, newBalance);
+            log.info("잔액 증가: {} → {}", account.getBalance(), newBalance);
+            
+            // 자산 차감
+            int remaining = quantity;
+            while (remaining > 0) {
+                int decreased = assetMapper.decreaseAssetQuantity(accountId, stockCode, remaining);
+                if (decreased == 0) {
+                    break; // 더 이상 차감할 자산 없음
+                }
+                remaining -= decreased;
+            }
+            log.info("자산 차감: {} 종목 {} 주 매도", stockCode, quantity);
+        }
+        
+        return result > 0;
+    }
+}

--- a/src/main/resources/mappers/history/BiasAlertMapper.xml
+++ b/src/main/resources/mappers/history/BiasAlertMapper.xml
@@ -13,20 +13,21 @@
         <result property="holdingDays" column="holdingDays"/>
     </resultMap>
 
-    <!-- 특정 종목의 보유 정보 조회 -->
     <select id="selectAssetForBiasCheck" resultMap="BiasAlertResultMap">
         SELECT 
             a.stock_code AS stockCode,
             s.stock_name AS stockName,
-            a.quantity,
-            a.avg_price AS avgPrice,
-            a.updated_at AS purchaseDate,
-            DATEDIFF(NOW(), a.updated_at) AS holdingDays
+            SUM(a.quantity) AS quantity,
+            AVG(a.avg_price) AS avgPrice,
+            MAX(a.updated_at) AS purchaseDate,
+            DATEDIFF(NOW(), MAX(a.updated_at)) AS holdingDays
         FROM asset a
         JOIN stock s ON a.stock_code = s.stock_code
         WHERE a.account_id = #{accountId}
           AND a.stock_code = #{stockCode}
           AND a.quantity > 0
+        GROUP BY a.stock_code, s.stock_name
+        LIMIT 1
     </select>
     
     <!-- 현재가 조회 -->
@@ -54,7 +55,8 @@
           AND status = 'COMPLETED'
           AND created_at >= DATE_SUB(NOW(), INTERVAL 5 DAY)
     </select>
-       <!-- 당일 등락률 조회 (FOMO용) -->
+    
+    <!-- 당일 등락률 조회 (FOMO용) -->
     <select id="selectDailyChangeRate" resultType="java.math.BigDecimal">
         SELECT 
             CASE 

--- a/src/main/resources/mappers/user/AccountMapper.xml
+++ b/src/main/resources/mappers/user/AccountMapper.xml
@@ -23,12 +23,14 @@
     SELECT account_id, user_id, account_number, balance
     FROM account
     WHERE user_id = #{userId}
+    LIMIT 1
   </select>
 
   <select id="selectByAccountId" resultMap="AccountMap">
     SELECT account_id, user_id, account_number, balance
     FROM account
     WHERE account_id = #{accountId}
+    LIMIT 1
   </select>
 
   <update id="updateBalance">

--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -44,8 +44,8 @@
                             <button class="detail-period-btn" data-period="M">월</button>
                             <button class="detail-period-btn" data-period="Y">년</button>
                         </div>
-					    <div id="detail-stockChart" style="width: 100%; height: 280px;"></div>
-					</section>
+                        <div id="detail-stockChart" style="width: 100%; height: 280px;"></div>
+                    </section>
                     <section class="detail-bottom-split">
                         <section class="detail-hoga-box">
                         </section>
@@ -63,7 +63,6 @@
                 <aside class="detail-right-panel">
                     <div class="detail-order-top">
                         <h3>주문하기</h3>
-                        <span class="detail-change-link">주문 방법 바꾸기</span>
                     </div>
                     <div class="detail-tab-group">
                         <button class="detail-tab-active" data-type="buy">매수</button>
@@ -72,43 +71,55 @@
                     </div>
                     <div class="detail-input-card">
                         <div class="detail-row">
-                            <span class="detail-card-label"> 
-                                <span id="tab-limit" class="detail-price-type detail-active-type" style="cursor:pointer;">지정가</span> | 
-                                <span id="tab-market" class="detail-price-type" style="cursor:pointer; color:#6B7280;">시장가</span>
-                            </span> 
-                            <span id="order-display-price" class="detail-big-price">129,300원</span>
+                            <span id="tab-limit" class="detail-price-type detail-active-type" style="cursor:pointer;">지정가</span><span style="color: var(--text-tertiary); margin: 0 2px;">|</span><span id="tab-market" class="detail-price-type" style="cursor:pointer; color:#6B7280;">시장가</span>
                         </div>
                         <div class="detail-row">
-                            <span>수량</span> <span class="detail-big-price">10주</span>
+                            <span>가격</span>
+                            <div class="detail-price-input-wrapper">
+                                <input type="text" class="detail-price-input" id="order-price-input" value="" placeholder="가격 입력" />
+                                <span class="detail-price-unit">원</span>
+                            </div>
+                        </div>
+                        <div class="detail-row">
+                            <span>수량</span>
+                            <div class="detail-quantity-wrapper">
+                                <button class="detail-qty-btn" id="qty-minus">-</button>
+                                <input type="number" class="detail-quantity-input" id="order-quantity-input" value="1" min="1" />
+                                <button class="detail-qty-btn" id="qty-plus">+</button>
+                                <span class="detail-quantity-unit">주</span>
+                            </div>
+                        </div>
+                        <div class="detail-quantity-preset">
+                            <button class="detail-preset-btn" data-percent="10">10%</button>
+                            <button class="detail-preset-btn" data-percent="25">25%</button>
+                            <button class="detail-preset-btn" data-percent="50">50%</button>
+                            <button class="detail-preset-btn" data-percent="100">최대</button>
                         </div>
                     </div>
 
+
                     <div class="detail-order-result">
                         <div class="detail-row">
-                            <span id="available-label">구매 가능 금액</span> <span class="detail-big-price"
-                                class="detail-money">1,293,000원</span>
-                        </div>
-                        <div class="detail-row">
-                            <span>내 주식 평균</span> <span class="detail-big-price"
-                                class="detail-money">129,300원</span>
+                            <span id="available-label">구매 가능 금액</span>
+                            <span class="detail-big-price">0원</span>
                         </div>
                         <div class="detail-total-row">
-                            <span>주문금액</span> <span class="detail-big-price"
-                                class="detail-total-money" id="total-money">1,293,000원</span>
+                            <span>주문금액</span>
+                            <span class="detail-total-money" id="total-money">0원</span>
                         </div>
                     </div>
                     <div class="detail-sentiment-section">
                         <div class="detail-sentiment-text">
-                            🔥 현재 투자자 <span id="sentiment-percent"></span>%가 <span class="detail-red-text" id="sentiment-direction"></span>쪽으로 몰려요!
+                            🔥 현재 투자자 <span id="sentiment-percent">50</span>%가 <span class="detail-red-text" id="sentiment-direction">매수</span>쪽으로 몰려요!
                         </div>
                         <div class="detail-percent-labels">
-                            <div style="width: 50%;" id="buy-percent"></div>
-                            <div style="width: 50%;" id="sell-percent"></div>
+                            <div style="width: 50%;" id="buy-percent">50%</div>
+                            <div style="width: 50%;" id="sell-percent">50%</div>
                         </div>
                         <div>
                             <div class="detail-progress-bar">
-                                <div class="detail-fill-buy" style="width: 78%;" id="buy-bar"></div>
-                                <div class="detail-fill-sell" style="width: 22%;" id="sell-bar"></div>
+                                <div class="detail-fill-buy" style="width: 50%;" id="buy-bar"></div>
+                                <div class="detail-fill-sell" style="width: 50%;" id="sell-bar"></div>
                             </div>
                         </div>
                     </div>
@@ -117,6 +128,43 @@
             </div>
         </main>
     </div>
+    
+    <!-- 주문 확인 팝업 -->
+    <div class="detail-order-modal" id="order-modal">
+        <div class="detail-modal-content">
+            <div class="detail-modal-header">
+                <h3 class="detail-modal-title" id="modal-title">매수 주문 확인</h3>
+                <button class="detail-modal-close" id="modal-close">×</button>
+            </div>
+            <div class="detail-modal-body">
+                <div class="detail-modal-info-row">
+                    <span class="detail-modal-label">종목명</span>
+                    <span class="detail-modal-value" id="modal-stock-name">삼성전자</span>
+                </div>
+                <div class="detail-modal-info-row">
+                    <span class="detail-modal-label">주문유형</span>
+                    <span class="detail-modal-value" id="modal-order-type">지정가</span>
+                </div>
+                <div class="detail-modal-info-row" id="modal-price-row">
+                    <span class="detail-modal-label">주문가격</span>
+                    <span class="detail-modal-value" id="modal-price">129,300원</span>
+                </div>
+                <div class="detail-modal-info-row">
+                    <span class="detail-modal-label">주문수량</span>
+                    <span class="detail-modal-value" id="modal-quantity">10주</span>
+                </div>
+                <div class="detail-modal-total">
+                    <span class="detail-modal-total-label">총 주문금액</span>
+                    <span class="detail-modal-total-value buy" id="modal-total">1,293,000원</span>
+                </div>
+            </div>
+            <div class="detail-modal-actions">
+                <button class="detail-modal-btn detail-modal-btn-cancel" id="modal-cancel">취소</button>
+                <button class="detail-modal-btn detail-modal-btn-confirm" id="modal-confirm">매수</button>
+            </div>
+        </div>
+    </div>
+    
     
 <!-- SockJS 라이브러리 -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/sockjs-client/1.5.1/sockjs.min.js"></script>

--- a/src/main/webapp/resources/css/stock/detail.css
+++ b/src/main/webapp/resources/css/stock/detail.css
@@ -1,163 +1,163 @@
 :root {
-	--primary-bg: #F5F7FB;
-	--secondary-bg: #FFFFFF;
-	--border-color: #E5E7EB;
-	--text-primary: #1F2937;
-	--text-secondary: #6B7280;
-	--text-tertiary: #9CA3AF;
-	--color-positive: #e22939;
-	--color-negative: #2271e9;
-	--shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.05);
-	--shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
-	--font-korean: 'Noto Sans KR', 'Pretendard', sans-serif;
+    --primary-bg: #F5F7FB;
+    --secondary-bg: #FFFFFF;
+    --border-color: #E5E7EB;
+    --text-primary: #1F2937;
+    --text-secondary: #6B7280;
+    --text-tertiary: #9CA3AF;
+    --color-positive: #e22939;
+    --color-negative: #2271e9;
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.05);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+    --font-korean: 'Noto Sans KR', 'Pretendard', sans-serif;
 }
 
 * {
-	box-sizing: border-box;
-	margin: 0;
-	padding: 0;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
 }
 
 body {
-	background-color: var(--primary-bg);
-	font-family: var(--font-korean);
-	overflow-x: hidden; /* 가로 스크롤 방지 */
+    background-color: var(--primary-bg);
+    font-family: var(--font-korean);
+    overflow-x: hidden; /* 가로 스크롤 방지 */
 }
 
 /* =========================================
    2. 메인 레이아웃 (Sidebar 대응)
    ========================================= */
 .detail-container {
-	display: flex;
-	min-height: 100vh;
-	background-color: var(--primary-bg);
+    display: flex;
+    min-height: 100vh;
+    background-color: var(--primary-bg);
 }
 
 /* Mission.css와 동일한 여백 구조 */
 .detail-main-content {
-	flex: 1;
-	margin-left: 260px; /* 사이드바 공간 확보 */
-	min-height: 100vh;
-	padding: 80px 50px;
-	width: calc(100% - 260px); /* 명시적 너비 계산 */
+    flex: 1;
+    margin-left: 260px; /* 사이드바 공간 확보 */
+    min-height: 100vh;
+    padding: 80px 50px;
+    width: calc(100% - 260px); /* 명시적 너비 계산 */
 }
 
 .detail-stock-container {
-	display: flex;
-	gap: 20px;
-	max-width: 1440px;
-	margin: 0 auto; /* 상하 마진은 padding으로 대체 */
-	align-items: flex-start; /* stretch 대신 start로 변경하여 높이 자연스럽게 */
+    display: flex;
+    gap: 20px;
+    max-width: 1440px;
+    margin: 0 auto; /* 상하 마진은 padding으로 대체 */
+    align-items: flex-start; /* stretch 대신 start로 변경하여 높이 자연스럽게 */
 }
 
 /* =========================================
    3. 왼쪽 패널 (종목정보, 차트, 커뮤니티)
    ========================================= */
 .detail-left-panel {
-	flex: 1;
-	display: flex;
-	flex-direction: column;
-	gap: 20px;
-	min-width: 0; /* Flex 자식 요소 넘침 방지 */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    min-width: 0; /* Flex 자식 요소 넘침 방지 */
 }
 
 /* 공통 카드 스타일 (Mission.css 스타일 적용) */
 .detail-stock-header,
 .detail-hoga-box,
 .detail-community-box {
-	background: var(--secondary-bg);
-	border: 1px solid var(--border-color);
-	border-radius: 20px; /* mission.css 처럼 둥글게 */
-	padding: 17px;
-	box-shadow: var(--shadow-sm);
-	transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-	display: flex;           /* 내부 요소를 유연하게 배치 */
-	flex-direction: column;  /* 위에서 아래로 쌓음 */
-	/* 높이는 이미 잡혀있거나 부모에 따름 */
-	overflow: hidden;
+    background: var(--secondary-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 20px; /* mission.css 처럼 둥글게 */
+    padding: 17px;
+    box-shadow: var(--shadow-sm);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    display: flex;           /* 내부 요소를 유연하게 배치 */
+    flex-direction: column;  /* 위에서 아래로 쌓음 */
+    /* 높이는 이미 잡혀있거나 부모에 따름 */
+    overflow: hidden;
 }
 
 .detail-stock-header:hover,
 .detail-chart-area:hover,
 .detail-hoga-box:hover,
 .detail-community-box:hover {
-	box-shadow: var(--shadow-md);
+    box-shadow: var(--shadow-md);
 }
 
 /* 헤더 영역 */
 .detail-stock-header {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	gap: 15px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 15px;
 }
 
 .detail-stock-header img {
-	width: 48px;
-	height: 48px;
-	object-fit: contain;
+    width: 48px;
+    height: 48px;
+    object-fit: contain;
 }
 
 .detail-text-col {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-	flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    flex: 1;
 }
 
 .detail-stock-name {
-	font-size: 20px;
-	font-weight: 700;
-	color: var(--text-primary);
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text-primary);
 }
 
 .stock-code {
-	font-size: 14px;
-	color: var(--text-secondary);
-	font-weight: 400;
-	margin-left: 8px;
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-weight: 400;
+    margin-left: 8px;
 }
 
 .detail-current-price h3 {
-	font-size: 24px;
-	font-weight: 800;
-	color: var(--text-primary);
+    font-size: 24px;
+    font-weight: 800;
+    color: var(--text-primary);
 }
 
 /* 관심종목 버튼 */
 .detail-favorite-btn {
-	background: none;
-	border: none;
-	font-size: 24px;
-	cursor: pointer;
-	color: #ddd;
-	transition: all 0.3s;
-	padding: 0;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #ddd;
+    transition: all 0.3s;
+    padding: 0;
 }
 
 .detail-favorite-btn:hover {
-	transform: scale(1.1);
+    transform: scale(1.1);
 }
 
 .detail-favorite-btn.active {
-	color: #fbbf24;
+    color: #fbbf24;
 }
 
 /* 차트 영역 */
 .detail-chart-area {
-	height: 350px;
-	width: 100%;
-	position: relative;
-	background-color: #ffffff;
-	background: var(--secondary-bg);
-	border: 1px solid var(--border-color);
-	border-radius: 20px;
-	padding: 17px;
-	box-shadow: var(--shadow-sm);
-	transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-	display: block;
-	flex-direction: column;
-	overflow: hidden;
+    height: 350px;
+    width: 100%;
+    position: relative;
+    background-color: #ffffff;
+    background: var(--secondary-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    padding: 17px;
+    box-shadow: var(--shadow-sm);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    display: block;
+    flex-direction: column;
+    overflow: hidden;
 }
 
 /* 차트 내부 영역 */
@@ -173,160 +173,160 @@ body {
 
 /* 하단 분할 영역 (호가/커뮤니티) */
 .detail-bottom-split {
-	display: flex;
-	gap: 20px;
-	height: 400px; /* 높이 고정 혹은 auto */
+    display: flex;
+    gap: 20px;
+    height: 400px; /* 높이 고정 혹은 auto */
 }
 
 .detail-hoga-box,
 .detail-community-box {
-	flex: 1;
-	overflow: hidden; /* 내부 스크롤 시 필요 */
+    flex: 1;
+    overflow: hidden; /* 내부 스크롤 시 필요 */
 }
 
 .detail-strong h3 {
-	font-size: 18px;
-	font-weight: 700;
-	color: var(--text-primary);
-	margin-bottom: 16px;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin-bottom: 16px;
 }
 
 /* =========================================
    4. 오른쪽 패널 (주문하기)
    ========================================= */
 .detail-right-panel {
-	width: 380px;
-	position: sticky;
-	top: 80px; /* 헤더 높이 고려 */
-	display: flex;
-	flex-direction: column;
-	gap: 20px;
-	background: var(--secondary-bg);
-	border: 1px solid var(--border-color);
-	border-radius: 20px;
-	padding: 24px;
-	box-shadow: var(--shadow-sm);
-	z-index: 10;
+    width: 380px;
+    position: sticky;
+    top: 80px; /* 헤더 높이 고려 */
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    background: var(--secondary-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    padding: 24px;
+    box-shadow: var(--shadow-sm);
+    z-index: 10;
 }
 
 .detail-order-top {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 4px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 4px;
 }
 
 .detail-order-top h3 {
-	font-size: 18px;
-	font-weight: 700;
-	color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
 }
 
 .detail-change-link {
-	font-size: 13px;
-	color: var(--text-secondary);
-	cursor: pointer;
-	text-decoration: underline;
+    font-size: 13px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    text-decoration: underline;
 }
 
 /* 탭 그룹 */
 .detail-tab-group {
-	display: flex;
-	background: #F3F4F6;
-	border-radius: 12px;
-	padding: 4px;
-	gap: 4px;
+    display: flex;
+    background: #F3F4F6;
+    border-radius: 12px;
+    padding: 4px;
+    gap: 4px;
 }
 
 .detail-tab, .detail-tab-active {
-	flex: 1;
-	padding: 10px;
-	border: none;
-	border-radius: 8px;
-	font-size: 14px;
-	font-weight: 600;
-	cursor: pointer;
-	transition: all 0.2s;
+    flex: 1;
+    padding: 10px;
+    border: none;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
 }
 
 .detail-tab-active {
-	background: #FFFFFF;
-	color: var(--text-primary);
-	box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    background: #FFFFFF;
+    color: var(--text-primary);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 }
 
 .detail-tab {
-	background: transparent;
-	color: var(--text-secondary);
+    background: transparent;
+    color: var(--text-secondary);
 }
 
 .detail-tab:hover {
-	color: var(--text-primary);
+    color: var(--text-primary);
 }
 
 /* 입력 카드 */
 .detail-input-card {
-	background: #F9FAFB;
-	border: 1px solid var(--border-color);
-	border-radius: 16px;
-	padding: 20px;
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
+    background: #F9FAFB;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
 }
 
 .detail-row {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	font-size: 14px;
-	color: var(--text-secondary);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+    color: var(--text-secondary);
 }
 
 .detail-active-type {
-	color: var(--text-primary);
-	font-weight: 700;
+    color: var(--text-primary);
+    font-weight: 700;
 }
 
 .detail-big-price {
-	font-size: 18px;
-	font-weight: 700;
-	color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary);
 }
 
 /* 주문 결과 */
 .detail-order-result {
-	padding: 10px 0;
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
+    padding: 10px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
 }
 
 .detail-total-row {
-	margin-top: 10px;
-	padding-top: 15px;
-	border-top: 1px solid var(--border-color);
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+    margin-top: 10px;
+    padding-top: 15px;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .detail-total-money {
-	font-size: 22px;
-	color: var(--color-positive); /* 매수일 때 색상 */
+    font-size: 22px;
+    color: var(--color-positive); /* 매수일 때 색상 */
 }
 
 /* 감정(Sentiment) 바 */
 .detail-sentiment-section {
-	margin-top: 10px;
+    margin-top: 10px;
 }
 
 .detail-sentiment-text {
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--text-secondary);
-	margin-bottom: 8px;
-	text-align: center;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    margin-bottom: 8px;
+    text-align: center;
 }
 
 .detail-red-text { color: var(--color-positive); }
@@ -334,19 +334,19 @@ body {
 .detail-blue-text { color: var(--color-negative); }
 
 .detail-percent-labels {
-	display: flex;
-	justify-content: space-between;
-	font-size: 12px;
-	font-weight: 700;
-	margin-bottom: 4px;
+    display: flex;
+    justify-content: space-between;
+    font-size: 12px;
+    font-weight: 700;
+    margin-bottom: 4px;
 }
 
 .detail-progress-bar {
-	display: flex;
-	height: 10px;
-	border-radius: 5px;
-	overflow: hidden;
-	background-color: #F3F4F6;
+    display: flex;
+    height: 10px;
+    border-radius: 5px;
+    overflow: hidden;
+    background-color: #F3F4F6;
 }
 
 .detail-fill-buy { background: var(--color-positive); }
@@ -354,22 +354,22 @@ body {
 
 /* 매수 버튼 */
 .detail-btn-submit {
-	width: 100%;
-	background: var(--color-positive);
-	color: #fff;
-	border: none;
-	border-radius: 16px;
-	padding: 18px;
-	font-size: 18px;
-	font-weight: 700;
-	cursor: pointer;
-	transition: background-color 0.2s;
-	margin-top: 10px;
+    width: 100%;
+    background: var(--color-positive);
+    color: #fff;
+    border: none;
+    border-radius: 16px;
+    padding: 18px;
+    font-size: 18px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    margin-top: 10px;
 }
 
 .detail-btn-submit:hover {
-	background: var(--color-positive);
-	transform: translateY(-1px);
+    background: var(--color-positive);
+    transform: translateY(-1px);
 }
 
 /* 매수매도비율 */
@@ -453,123 +453,598 @@ body {
    ========================================= */
 
 @media (max-width: 1400px) {
-	.detail-main-content {
-		padding: 80px 32px;
-	}
+    .detail-main-content {
+        padding: 80px 32px;
+    }
 }
 
 /* 1200px 이하 - 레이아웃 변경 (Grid 1열 처럼 동작) */
 @media (max-width: 1200px) {
-	.detail-main-content {
-		padding: 80px 24px;
-	}
+    .detail-main-content {
+        padding: 80px 24px;
+    }
 
-	/* 좌우 배치를 상하 배치로 변경 */
-	.detail-stock-container {
-		flex-direction: column;
-		align-items: stretch; /* 가로 가득 차게 */
-	}
+    /* 좌우 배치를 상하 배치로 변경 */
+    .detail-stock-container {
+        flex-direction: column;
+        align-items: stretch; /* 가로 가득 차게 */
+    }
 
-	/* 오른쪽 패널(주문) 스타일 변경 */
-	.detail-right-panel {
-		width: 100%;
-		position: static; /* sticky 해제 */
-		order: 1; /* 차트 아래로 배치 */
-		margin-top: 20px;
-	}
+    /* 오른쪽 패널(주문) 스타일 변경 */
+    .detail-right-panel {
+        width: 100%;
+        position: static; /* sticky 해제 */
+        order: 1; /* 차트 아래로 배치 */
+        margin-top: 20px;
+    }
 
-	/* 차트 높이 조정 */
-	.detail-chart-area {
-		height: 350px;
-	}
+    /* 차트 높이 조정 */
+    .detail-chart-area {
+        height: 350px;
+    }
 }
 
 /* 768px 이하 (태블릿/모바일) - 사이드바 축소 및 폰트 조정 */
 @media (max-width: 768px) {
-	.detail-main-content {
-		margin-left: 50px; /* 사이드바 축소 대응 */
-		width: calc(100% - 50px);
-		padding: 80px 20px 40px; /* 상단 패딩 증가 */
-	}
+    .detail-main-content {
+        margin-left: 50px; /* 사이드바 축소 대응 */
+        width: calc(100% - 50px);
+        padding: 80px 20px 40px; /* 상단 패딩 증가 */
+    }
 
-	/* 패널 내부 패딩 축소 */
-	.detail-stock-header,
-	.detail-chart-area,
-	.detail-hoga-box,
-	.detail-community-box,
-	.detail-right-panel {
-		padding: 20px;
-	}
+    /* 패널 내부 패딩 축소 */
+    .detail-stock-header,
+    .detail-chart-area,
+    .detail-hoga-box,
+    .detail-community-box,
+    .detail-right-panel {
+        padding: 20px;
+    }
 
-	.detail-strong {
-		padding: 20px 20px 10px 20px;
-	}
+    .detail-strong {
+        padding: 20px 20px 10px 20px;
+    }
 
-	/* 하단 분할 영역(호가/커뮤니티) 세로 배치 */
-	.detail-bottom-split {
-		flex-direction: column;
-		height: auto;
-	}
+    /* 하단 분할 영역(호가/커뮤니티) 세로 배치 */
+    .detail-bottom-split {
+        flex-direction: column;
+        height: auto;
+    }
 
-	.detail-hoga-box,
-	.detail-community-box {
-		min-height: 400px; /* 충분한 높이 확보 */
-	}
+    .detail-hoga-box,
+    .detail-community-box {
+        min-height: 400px; /* 충분한 높이 확보 */
+    }
 
-	/* 폰트 사이즈 조정 (MyPage 스타일) */
-	.detail-current-price h3 {
-		font-size: 28px;
-	}
+    /* 폰트 사이즈 조정 (MyPage 스타일) */
+    .detail-current-price h3 {
+        font-size: 28px;
+    }
 
-	.detail-total-money {
-		font-size: 20px;
-	}
+    .detail-total-money {
+        font-size: 20px;
+    }
 
-	.detail-chart-area {
-		height: 300px;
-	}
+    .detail-chart-area {
+        height: 300px;
+    }
 }
 
 /* 480px 이하 (모바일 디테일) */
 @media (max-width: 480px) {
-	.detail-main-content {
-		margin-left: 0; /* 사이드바 완전 숨김 시 */
-		width: 100%;
-		padding: 120px 16px 40px;
-	}
+    .detail-main-content {
+        margin-left: 0; /* 사이드바 완전 숨김 시 */
+        width: 100%;
+        padding: 120px 16px 40px;
+    }
 
-	.detail-stock-header {
-		flex-direction: column;
-		align-items: flex-start;
-		gap: 12px;
-	}
+    .detail-stock-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
 }
 
 .detail-chart-period-buttons {
-	display: flex;
-	gap: 8px;
-	padding: 8px 10px;
-	flex-shrink: 0;
-	border-radius: 8px 8px 0 0;
-	border-bottom: 1px solid var(--border-color);
+    display: flex;
+    gap: 8px;
+    padding: 8px 10px;
+    flex-shrink: 0;
+    border-radius: 8px 8px 0 0;
+    border-bottom: 1px solid var(--border-color);
 }
 
 .detail-period-btn {
-	padding: 8px 16px;
-	border: 1px solid #ddd;
-	background-color: white;
-	border-radius: 4px;
-	cursor: pointer;
-	font-size: 14px;
-	transition: all 0.3s;
+    padding: 8px 16px;
+    border: 1px solid #ddd;
+    background-color: white;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: all 0.3s;
 }
 
 .detail-period-btn:hover {
-	background-color: #f0f0f0;
+    background-color: #f0f0f0;
 }
 
 .detail-period-active {
-	background-color: #2271e9;
-	color: white;
-	border-color: #2271e9;
+    background-color: #2271e9;
+    color: white;
+    border-color: #2271e9;
+}
+
+/* =========================================
+   주문 입력 UI 스타일
+   ========================================= */
+
+/* 입력 카드 크기 축소 */
+.detail-input-card {
+    background: #F9FAFB;
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+/* 지정가|시장가 스타일 */
+.detail-price-type {
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.detail-active-type {
+    color: var(--text-primary) !important;
+    font-weight: 700;
+}
+
+/* detail-row 기본 스타일 */
+.detail-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+    color: var(--text-secondary);
+}
+
+.detail-row > span:first-child {
+    min-width: 40px;
+    font-weight: 500;
+}
+
+/* 가격 입력 */
+.detail-price-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    justify-content: flex-end;
+}
+
+.detail-price-input {
+    width: 180px;
+    padding: 12px 14px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-align: right;
+    background: #fff;
+    transition: border-color 0.2s;
+}
+
+.detail-price-input:focus {
+    outline: none;
+    border-color: var(--text-primary);
+}
+
+.detail-price-input:disabled {
+    background: #f3f4f6;
+    color: var(--text-secondary);
+    cursor: not-allowed;
+}
+
+/* 수량 입력 */
+.detail-quantity-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    justify-content: flex-end;
+}
+
+.detail-quantity-input {
+    width: 80px;
+    padding: 12px 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-align: center;
+    background: #fff;
+    transition: border-color 0.2s;
+}
+
+.detail-quantity-input:focus {
+    outline: none;
+    border-color: var(--text-primary);
+}
+
+.detail-quantity-input::-webkit-outer-spin-button,
+.detail-quantity-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.detail-quantity-input[type=number] {
+    -moz-appearance: textfield;
+}
+
+/* +/- 버튼 */
+.detail-qty-btn {
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: #fff;
+    color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.detail-qty-btn:hover {
+    background: #f3f4f6;
+    border-color: var(--text-primary);
+}
+
+.detail-qty-btn:active {
+    transform: scale(0.95);
+}
+
+/* 원과 주 정렬 */
+.detail-price-unit,
+.detail-quantity-unit {
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-weight: 600;
+    min-width: 24px;
+    text-align: left;
+}
+
+/* 퍼센트 버튼 */
+.detail-quantity-preset {
+    display: flex;
+    gap: 8px;
+    margin-top: 0;
+}
+
+.detail-preset-btn {
+    flex: 1;
+    padding: 10px;
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background: #fff;
+    color: var(--text-secondary);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.detail-preset-btn:hover {
+    background: #f3f4f6;
+    border-color: var(--text-primary);
+    color: var(--text-primary);
+}
+
+.detail-preset-btn:active {
+    transform: scale(0.95);
+}
+
+.detail-preset-btn.active {
+    background: var(--text-primary);
+    color: #fff;
+    border-color: var(--text-primary);
+}
+
+/* 주문 결과 정렬 */
+.detail-order-result {
+    padding: 4px 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.detail-order-result .detail-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.detail-order-result .detail-row span:first-child {
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.detail-order-result .detail-row .detail-big-price {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.detail-total-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 4px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-color);
+}
+
+.detail-total-row span:first-child {
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.detail-total-money {
+    font-size: 19px;
+    font-weight: 800;
+    color: var(--color-positive);
+}
+
+/* 매도 모드 */
+.detail-btn-submit.sell-mode {
+    background: var(--color-negative);
+}
+
+.detail-btn-submit.sell-mode:hover {
+    background: #1c5ac7;
+}
+
+/* =========================================
+   주문 확인 팝업
+   ========================================= */
+
+.detail-order-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    align-items: center;
+    justify-content: center;
+    animation: fadeIn 0.2s ease;
+}
+
+.detail-order-modal.active {
+    display: flex;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+.detail-modal-content {
+    background: #fff;
+    border-radius: 20px;
+    padding: 32px;
+    width: 90%;
+    max-width: 420px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    animation: slideUp 0.3s ease;
+}
+
+@keyframes slideUp {
+    from {
+        transform: translateY(30px);
+        opacity: 0;
+    }
+    to {
+        transform: translateY(0);
+        opacity: 1;
+    }
+}
+
+.detail-modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 24px;
+}
+
+.detail-modal-title {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.detail-modal-close {
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.2s;
+    padding: 0;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.detail-modal-close:hover {
+    color: var(--text-primary);
+}
+
+.detail-modal-body {
+    margin-bottom: 24px;
+}
+
+.detail-modal-info-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.detail-modal-info-row:first-child {
+    padding-top: 0;
+}
+
+.detail-modal-info-row:last-child {
+    border-bottom: none;
+}
+
+.detail-modal-label {
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.detail-modal-value {
+    font-size: 16px;
+    color: var(--text-primary);
+    font-weight: 700;
+}
+
+.detail-modal-total {
+    background: #F9FAFB;
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 16px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.detail-modal-total-label {
+    font-size: 16px;
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.detail-modal-total-value {
+    font-size: 22px;
+    font-weight: 800;
+}
+
+.detail-modal-total-value.buy {
+    color: var(--color-positive);
+}
+
+.detail-modal-total-value.sell {
+    color: var(--color-negative);
+}
+
+.detail-modal-actions {
+    display: flex;
+    gap: 12px;
+}
+
+.detail-modal-btn {
+    flex: 1;
+    padding: 16px;
+    border: none;
+    border-radius: 12px;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.detail-modal-btn-cancel {
+    background: #F3F4F6;
+    color: var(--text-primary);
+}
+
+.detail-modal-btn-cancel:hover {
+    background: #E5E7EB;
+}
+
+.detail-modal-btn-confirm {
+    background: var(--color-positive);
+    color: #fff;
+}
+
+.detail-modal-btn-confirm:hover {
+    background: #c91f2c;
+    transform: translateY(-1px);
+}
+
+.detail-modal-btn-confirm.sell {
+    background: var(--color-negative);
+}
+
+.detail-modal-btn-confirm.sell:hover {
+    background: #1c5ac7;
+}
+
+@media (max-width: 480px) {
+    .detail-modal-content {
+        padding: 24px;
+        max-width: 90%;
+    }
+    
+    .detail-modal-title {
+        font-size: 18px;
+    }
+    
+    .detail-modal-actions {
+        flex-direction: column;
+    }
+    
+    .detail-modal-btn {
+        width: 100%;
+    }
+}
+
+/* 지정가|시장가 행만 왼쪽 정렬 */
+.detail-input-card > .detail-row:first-child {
+    justify-content: flex-start;
+}
+
+/* 매수/매도 퍼센트 라벨 정렬 수정 */
+.detail-percent-labels {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    margin-bottom: 8px;
+}
+
+.detail-percent-labels > div:first-child {
+    text-align: left !important;
+    width: 50%;
+}
+
+.detail-percent-labels > div:last-child {
+    text-align: right !important;
+    width: 50%;
+}
+
+#buy-percent {
+    text-align: left !important;
+}
+
+#sell-percent {
+    text-align: right !important;
 }

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -777,13 +777,7 @@ document.addEventListener('DOMContentLoaded', async function() {
                 availableLabel.textContent = '구매 가능 금액';
                 sentimentDir.textContent = '매수';
                 sentimentDir.className = 'detail-red-text';
-                sentimentPercent.textContent = '78';
-                buyPercent.textContent = '78%';
-                buyPercent.style.width = '78%';
-                sellPercent.textContent = '22%';
-                sellPercent.style.width = '22%';
-                buyBar.style.width = '78%';
-                sellBar.style.width = '22%';
+
                 
                 // 매수 탭 클릭 시 편향 체크 (우선순위: 매몰비용 > 손실회피 > FOMO)
                 const urlParams = new URLSearchParams(window.location.search);
@@ -849,13 +843,7 @@ document.addEventListener('DOMContentLoaded', async function() {
                 availableLabel.textContent = '판매 가능 수량';
                 sentimentDir.textContent = '매도';
                 sentimentDir.className = 'detail-blue-text';
-                sentimentPercent.textContent = '22';
-                buyPercent.textContent = '22%';
-                buyPercent.style.width = '22%';
-                sellPercent.textContent = '78%';
-                sellPercent.style.width = '78%';
-                buyBar.style.width = '22%';
-                sellBar.style.width = '78%';
+
                 
                 // 매도 탭 클릭 시 위험회피 체크
                 const urlParams2 = new URLSearchParams(window.location.search);
@@ -1047,3 +1035,563 @@ function checkMockStatus() {
 window.enableMockMode = enableMockMode;
 window.disableMockMode = disableMockMode;
 window.checkMockStatus = checkMockStatus;
+
+// =========================================
+// 주문 UI 기능 (완전 수정 버전)
+// detail.js 파일 맨 끝에 추가하세요
+// =========================================
+
+(function() {
+    console.log('=== 주문 UI 초기화 시작 ===');
+    
+    const tabLimit = document.getElementById('tab-limit');
+    const tabMarket = document.getElementById('tab-market');
+    const priceInput = document.getElementById('order-price-input');
+    const quantityInput = document.getElementById('order-quantity-input');
+    const qtyMinus = document.getElementById('qty-minus');
+    const qtyPlus = document.getElementById('qty-plus');
+    const submitBtn = document.getElementById('submit-btn');
+    const orderModal = document.getElementById('order-modal');
+    const modalClose = document.getElementById('modal-close');
+    const modalCancel = document.getElementById('modal-cancel');
+    const modalConfirm = document.getElementById('modal-confirm');
+    
+    const tabBtns = document.querySelectorAll('.detail-tab, .detail-tab-active');
+    const presetBtns = document.querySelectorAll('.detail-preset-btn');
+    
+    let currentOrderType = 'limit';
+    let currentTransactionType = 'buy';
+    let currentPrice = 0;
+    let availableBalance = 0;
+    let ownedQuantity = 0; // 보유 주식 수량
+    let isBalanceLoaded = false;
+    let isQuantityLoaded = false;
+    
+    // ===== 실시간 현재가 가져오기 =====
+    function getCurrentPrice() {
+        const priceElement = document.getElementById('detail-current-price-h3');
+        if (priceElement) {
+            const priceText = priceElement.textContent.trim();
+            const price = parseInt(priceText.replace(/[^0-9]/g, '')) || 0;
+            if (price > 0) {
+                currentPrice = price;
+                console.log('현재가 업데이트:', currentPrice.toLocaleString());
+                return currentPrice;
+            }
+        }
+        return currentPrice;
+    }
+    
+    // ===== 서버에서 잔액 가져오기 =====
+    function fetchAvailableBalance() {
+        console.log('잔액 조회 시작...');
+        fetch(contextPath + '/api/account/balance')
+            .then(response => {
+                console.log('잔액 API 응답 상태:', response.status);
+                return response.json();
+            })
+            .then(data => {
+                console.log('잔액 조회 응답:', data);
+                if (data.success) {
+                    availableBalance = data.balance || 0;
+                    isBalanceLoaded = true;
+                    console.log('✓ 잔액 로드 성공:', availableBalance.toLocaleString() + '원');
+                    updateBalanceDisplay();
+                } else {
+                    console.error('잔액 조회 실패:', data.message);
+                    // 실패해도 0으로 표시
+                    availableBalance = 0;
+                    isBalanceLoaded = true;
+                    updateBalanceDisplay();
+                }
+            })
+            .catch(error => {
+                console.error('잔액 조회 오류:', error);
+                // 오류 시에도 0으로 표시
+                availableBalance = 0;
+                isBalanceLoaded = true;
+                updateBalanceDisplay();
+            });
+    }
+    
+    // ===== 보유 주식 수량 가져오기 (매도용) =====
+    function fetchOwnedQuantity() {
+        const stockCode = new URLSearchParams(window.location.search).get('code');
+        if (!stockCode) {
+            console.error('종목 코드 없음');
+            return;
+        }
+        
+        console.log('보유 수량 조회 시작...');
+        fetch(contextPath + '/api/account/holdings?stockCode=' + stockCode)
+            .then(response => response.json())
+            .then(data => {
+                console.log('보유 수량 응답:', data);
+                if (data.success) {
+                    ownedQuantity = data.quantity || 0;
+                    isQuantityLoaded = true;
+                    console.log('✓ 보유 수량:', ownedQuantity + '주');
+                } else {
+                    ownedQuantity = 0;
+                    isQuantityLoaded = true;
+                }
+            })
+            .catch(error => {
+                console.error('보유 수량 조회 오류:', error);
+                ownedQuantity = 0;
+                isQuantityLoaded = true;
+            });
+    }
+    
+    // ===== 화면 표시 업데이트 =====
+    function updateBalanceDisplay() {
+        const labelElement = document.getElementById('available-label');
+        const balanceElement = document.querySelector('.detail-order-result .detail-row .detail-big-price');
+        
+        if (currentTransactionType === 'buy') {
+            labelElement.textContent = '구매 가능 금액';
+            if (balanceElement) {
+                balanceElement.textContent = availableBalance.toLocaleString() + '원';
+            }
+        } else if (currentTransactionType === 'sell') {
+            labelElement.textContent = '판매 가능 수량';
+            if (balanceElement) {
+                balanceElement.textContent = ownedQuantity.toLocaleString() + '주';
+            }
+        }
+    }
+    
+    // ===== 초기 설정 =====
+    function initialize() {
+        console.log('초기 설정 시작...');
+        
+        // 현재가 가져오기
+        getCurrentPrice();
+        
+        // 가격 입력 필드 초기화
+        if (priceInput && currentPrice > 0) {
+            priceInput.value = currentPrice.toLocaleString();
+            console.log('✓ 가격 초기화:', priceInput.value);
+        }
+        
+        // 잔액 및 보유 수량 가져오기
+        fetchAvailableBalance();
+        fetchOwnedQuantity();
+        
+        // 초기 주문금액 계산
+        setTimeout(updateOrderAmount, 100);
+        
+        console.log('✓ 초기 설정 완료');
+    }
+    
+    // 페이지 로드 후 초기화
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialize);
+    } else {
+        initialize();
+    }
+    
+    // 지정가/시장가 탭 전환
+    if (tabLimit) {
+        tabLimit.addEventListener('click', function() {
+            console.log('지정가 선택');
+            currentOrderType = 'limit';
+            tabLimit.classList.add('detail-active-type');
+            tabLimit.style.color = '';
+            tabMarket.classList.remove('detail-active-type');
+            tabMarket.style.color = '#6B7280';
+            
+            priceInput.disabled = false;
+            getCurrentPrice();
+            priceInput.value = currentPrice.toLocaleString();
+            updateOrderAmount();
+        });
+    }
+    
+    if (tabMarket) {
+        tabMarket.addEventListener('click', function() {
+            console.log('시장가 선택');
+            currentOrderType = 'market';
+            tabMarket.classList.add('detail-active-type');
+            tabMarket.style.color = '';
+            tabLimit.classList.remove('detail-active-type');
+            tabLimit.style.color = '#6B7280';
+            
+            // 시장가일 때도 현재가를 숫자로 표시
+            priceInput.disabled = true;
+            getCurrentPrice();
+            priceInput.value = currentPrice.toLocaleString();
+            updateOrderAmount();
+        });
+    }
+    
+    // 매수/매도 탭 전환
+    tabBtns.forEach(btn => {
+        btn.addEventListener('click', function() {
+            const type = this.getAttribute('data-type');
+            
+            tabBtns.forEach(b => {
+                b.classList.remove('detail-tab-active');
+                b.classList.add('detail-tab');
+            });
+            this.classList.remove('detail-tab');
+            this.classList.add('detail-tab-active');
+            
+            if (type === 'buy') {
+                currentTransactionType = 'buy';
+                submitBtn.textContent = '매수';
+                submitBtn.classList.remove('sell-mode');
+                updateBalanceDisplay();
+            } else if (type === 'sell') {
+                currentTransactionType = 'sell';
+                submitBtn.textContent = '매도';
+                submitBtn.classList.add('sell-mode');
+                fetchOwnedQuantity(); // 매도 시 보유 수량 새로고침
+                setTimeout(updateBalanceDisplay, 100);
+            }
+        });
+    });
+    
+    // 수량 조절
+    if (qtyMinus) {
+        qtyMinus.addEventListener('click', function() {
+            let qty = parseInt(quantityInput.value) || 1;
+            if (qty > 1) {
+                quantityInput.value = qty - 1;
+                updateOrderAmount();
+            }
+        });
+    }
+    
+    if (qtyPlus) {
+        qtyPlus.addEventListener('click', function() {
+            let qty = parseInt(quantityInput.value) || 0;
+            quantityInput.value = qty + 1;
+            updateOrderAmount();
+        });
+    }
+    
+    if (quantityInput) {
+        quantityInput.addEventListener('input', updateOrderAmount);
+    }
+    
+    if (priceInput) {
+        priceInput.addEventListener('input', function() {
+            if (currentOrderType === 'limit') {
+                let value = this.value.replace(/[^0-9]/g, '');
+                if (value) {
+                    this.value = parseInt(value).toLocaleString();
+                }
+                updateOrderAmount();
+            }
+        });
+    }
+    
+    // ===== 퍼센트 버튼 =====
+    presetBtns.forEach(btn => {
+        btn.addEventListener('click', function() {
+            console.log('=== 퍼센트 버튼 클릭 ===');
+            
+            const percent = this.getAttribute('data-percent');
+            console.log('선택된 퍼센트:', percent + '%');
+            
+            // 버튼 활성화
+            presetBtns.forEach(b => b.classList.remove('active'));
+            this.classList.add('active');
+            
+            // 현재가 확인
+            getCurrentPrice();
+            
+            let price = currentPrice;
+            if (currentOrderType === 'limit') {
+                const inputPrice = parseInt(priceInput.value.replace(/[^0-9]/g, ''));
+                if (inputPrice > 0) {
+                    price = inputPrice;
+                }
+            }
+            
+            let quantity = 0;
+            
+            if (currentTransactionType === 'buy') {
+                // 매수: 잔액 기반 계산
+                if (!isBalanceLoaded) {
+                    alert('잔액 정보를 불러오는 중입니다.\n잠시 후 다시 시도해주세요.');
+                    return;
+                }
+                
+                if (availableBalance <= 0) {
+                    alert('구매 가능 금액이 없습니다.');
+                    return;
+                }
+                
+                console.log('매수 계산:', { percent: percent + '%', price: price.toLocaleString(), balance: availableBalance.toLocaleString() });
+                
+                if (price > 0) {
+                    if (percent == 100) {
+                        quantity = Math.floor(availableBalance / price);
+                    } else {
+                        quantity = Math.floor((availableBalance * percent / 100) / price);
+                    }
+                }
+            } else if (currentTransactionType === 'sell') {
+                // 매도: 보유 수량 기반 계산
+                if (!isQuantityLoaded) {
+                    alert('보유 수량 정보를 불러오는 중입니다.\n잠시 후 다시 시도해주세요.');
+                    return;
+                }
+                
+                if (ownedQuantity <= 0) {
+                    alert('판매 가능한 주식이 없습니다.');
+                    return;
+                }
+                
+                console.log('매도 계산:', { percent: percent + '%', ownedQuantity: ownedQuantity });
+                
+                if (percent == 100) {
+                    quantity = ownedQuantity;
+                } else {
+                    quantity = Math.floor(ownedQuantity * percent / 100);
+                }
+            }
+            
+            quantity = Math.max(1, quantity);
+            console.log('→ 계산된 수량:', quantity + '주');
+            quantityInput.value = quantity;
+            updateOrderAmount();
+        });
+    });
+    
+    // ===== 주문 금액 업데이트 =====
+    function updateOrderAmount() {
+        let price = 0;
+        
+        if (currentOrderType === 'limit') {
+            price = parseInt(priceInput.value.replace(/[^0-9]/g, '')) || 0;
+        } else {
+            getCurrentPrice();
+            price = currentPrice;
+        }
+        
+        const quantity = parseInt(quantityInput.value) || 0;
+        const totalMoney = price * quantity;
+        
+        const totalMoneyElement = document.getElementById('total-money');
+        if (totalMoneyElement) {
+            if (totalMoney > 0) {
+                totalMoneyElement.textContent = totalMoney.toLocaleString() + '원';
+            } else {
+                totalMoneyElement.textContent = '0원';
+            }
+        }
+    }
+    
+    // 매수/매도 버튼
+    if (submitBtn) {
+        submitBtn.addEventListener('click', function() {
+            getCurrentPrice();
+            
+            const quantity = parseInt(quantityInput.value) || 0;
+            let price = 0;
+            
+            if (currentOrderType === 'limit') {
+                price = parseInt(priceInput.value.replace(/[^0-9]/g, '')) || 0;
+                if (price <= 0) {
+                    alert('가격을 입력해주세요.');
+                    return;
+                }
+            } else {
+                price = currentPrice;
+                if (price <= 0) {
+                    alert('현재가를 확인할 수 없습니다.');
+                    return;
+                }
+            }
+            
+            if (quantity <= 0) {
+                alert('수량을 입력해주세요.');
+                return;
+            }
+            
+            // 매수 검증
+            if (currentTransactionType === 'buy') {
+                if (!isBalanceLoaded) {
+                    alert('잔액 정보를 불러오는 중입니다.\n잠시 후 다시 시도해주세요.');
+                    return;
+                }
+                
+                const totalPrice = price * quantity;
+                if (totalPrice > availableBalance) {
+                    alert('구매 가능 금액이 부족합니다.\n\n필요 금액: ' + totalPrice.toLocaleString() + '원\n보유 금액: ' + availableBalance.toLocaleString() + '원');
+                    return;
+                }
+            }
+            
+            // 매도 검증
+            if (currentTransactionType === 'sell') {
+                if (!isQuantityLoaded) {
+                    alert('보유 수량 정보를 불러오는 중입니다.\n잠시 후 다시 시도해주세요.');
+                    return;
+                }
+                
+                if (quantity > ownedQuantity) {
+                    alert('판매 가능한 수량이 부족합니다.\n\n주문 수량: ' + quantity + '주\n보유 수량: ' + ownedQuantity + '주');
+                    return;
+                }
+            }
+            
+            updateModalInfo(price, quantity);
+            orderModal.classList.add('active');
+        });
+    }
+    
+    // 모달 정보 업데이트
+    function updateModalInfo(price, quantity) {
+        const stockName = document.querySelector('.detail-stock-name').textContent.trim().split(' ')[0];
+        const orderTypeText = currentOrderType === 'limit' ? '지정가' : '시장가';
+        const totalMoney = price * quantity;
+        
+        document.getElementById('modal-title').textContent = 
+            currentTransactionType === 'buy' ? '매수 주문 확인' : '매도 주문 확인';
+        document.getElementById('modal-stock-name').textContent = stockName;
+        document.getElementById('modal-order-type').textContent = orderTypeText;
+        
+        const priceRow = document.getElementById('modal-price-row');
+        priceRow.style.display = 'flex';
+        if (currentOrderType === 'market') {
+            document.getElementById('modal-price').textContent = price.toLocaleString() + '원 (시장가)';
+        } else {
+            document.getElementById('modal-price').textContent = price.toLocaleString() + '원';
+        }
+        
+        document.getElementById('modal-quantity').textContent = quantity + '주';
+        
+        const totalElement = document.getElementById('modal-total');
+        totalElement.textContent = totalMoney.toLocaleString() + '원';
+        
+        totalElement.classList.remove('buy', 'sell');
+        totalElement.classList.add(currentTransactionType);
+        
+        const confirmBtn = document.getElementById('modal-confirm');
+        confirmBtn.textContent = currentTransactionType === 'buy' ? '매수' : '매도';
+        confirmBtn.classList.remove('buy', 'sell');
+        confirmBtn.classList.add(currentTransactionType);
+    }
+    
+    // 모달 닫기
+    if (modalClose) {
+        modalClose.addEventListener('click', () => orderModal.classList.remove('active'));
+    }
+    if (modalCancel) {
+        modalCancel.addEventListener('click', () => orderModal.classList.remove('active'));
+    }
+    if (orderModal) {
+        orderModal.addEventListener('click', function(e) {
+            if (e.target === orderModal) orderModal.classList.remove('active');
+        });
+    }
+    
+    // 주문 확인
+    if (modalConfirm) {
+        modalConfirm.addEventListener('click', function() {
+            const stockCode = new URLSearchParams(window.location.search).get('code');
+            const quantity = parseInt(quantityInput.value) || 0;
+            
+            let price = 0;
+            if (currentOrderType === 'limit') {
+                price = parseInt(priceInput.value.replace(/[^0-9]/g, '')) || 0;
+            } else {
+                price = currentPrice;
+            }
+            
+            const orderData = {
+                stockCode: stockCode,
+                transactionType: currentTransactionType.toUpperCase(),
+                orderType: currentOrderType.toUpperCase(),
+                quantity: quantity,
+                orderPrice: price
+            };
+            
+            console.log('주문 전송:', orderData);
+            
+            fetch(contextPath + '/api/stock/order', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(orderData)
+            })
+            .then(response => response.json())
+            .then(data => {
+                console.log('주문 결과:', data);
+                
+                if (data.success) {
+                    alert('주문이 완료되었습니다.');
+                    orderModal.classList.remove('active');
+                    
+                    quantityInput.value = '1';
+                    if (currentOrderType === 'limit') {
+                        getCurrentPrice();
+                        priceInput.value = currentPrice.toLocaleString();
+                    }
+                    updateOrderAmount();
+                    presetBtns.forEach(b => b.classList.remove('active'));
+                    
+                    // 잔액/보유수량 새로고침
+                    setTimeout(() => {
+                        fetchAvailableBalance();
+                        fetchOwnedQuantity();
+                    }, 1000);
+                } else {
+                    alert('주문 실패: ' + (data.message || '알 수 없는 오류'));
+                }
+            })
+            .catch(error => {
+                console.error('주문 오류:', error);
+                alert('주문 중 오류가 발생했습니다.');
+            });
+        });
+    }
+    
+    // 실시간 가격 감지
+    const priceElement = document.getElementById('detail-current-price-h3');
+    if (priceElement) {
+        const observer = new MutationObserver(function() {
+            const prevPrice = currentPrice;
+            getCurrentPrice();
+            
+            if (prevPrice !== currentPrice) {
+                console.log('가격 변동:', prevPrice.toLocaleString() + '원 → ' + currentPrice.toLocaleString() + '원');
+                
+                // 지정가이고 입력값이 이전 가격이었으면 새 가격으로 업데이트
+                if (currentOrderType === 'limit') {
+                    const inputPrice = parseInt(priceInput.value.replace(/[^0-9]/g, '')) || 0;
+                    if (inputPrice === 0 || inputPrice === prevPrice) {
+                        priceInput.value = currentPrice.toLocaleString();
+                    }
+                }
+                
+                // 시장가일 때 자동 업데이트
+                if (currentOrderType === 'market') {
+                    priceInput.value = currentPrice.toLocaleString();
+                    updateOrderAmount();
+                }
+            }
+        });
+        
+        observer.observe(priceElement, {
+            childList: true,
+            characterData: true,
+            subtree: true
+        });
+        
+        console.log('✓ 실시간 가격 감지 시작');
+    }
+    
+    // 주기적 새로고침 (30초마다)
+    setInterval(() => {
+        fetchAvailableBalance();
+        if (currentTransactionType === 'sell') {
+            fetchOwnedQuantity();
+        }
+    }, 30000);
+    
+    console.log('=== 주문 UI 초기화 완료 ===');
+})();


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #174 

---

### 📝 작업 내용
종목 상세페이지에서 사용자가 직접 매수·매도 주문을 진행할 수 있는 기능을 구현했습니다.
지정가 / 시장가 주문 방식, 수량 입력, 주문 확인 팝업을 포함한 주문 프로세스를 단계적으로 구성했습니다.
주요 구현 사항
지정가 / 시장가 주문 방식 선택
실시간 주문 데이터 적용
수량 입력 및 주문 금액 자동 계산
매수 / 매도 UI 구현
주문 전 확인 팝업 노출 (종목명, 가격, 수량, 총 금액)
주문 검증 로직 (잔액 부족 / 보유 수량 부족)

### 📷 스크린샷 (선택)
![매수](https://github.com/user-attachments/assets/b98ad7d8-fa81-479e-b367-f271179bd206)
![매수2](https://github.com/user-attachments/assets/2143de2c-9997-4d88-ac98-11aded84e554)
![매도](https://github.com/user-attachments/assets/c4ddbb5e-dfe7-485b-a14c-a367d5e6a84b)
![매도2](https://github.com/user-attachments/assets/e0232d84-a8ca-4ccf-9e5f-2c3e6ec93c6b)
![수정필요](https://github.com/user-attachments/assets/58123c41-f803-4060-a400-49e46b557eff)
매도를 하면 -으로 표시가 되어 수정해야합니다!

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
