### PR TITLE
Refactor: 종목 차트에 실시간 현재가 동기화

### DIFF
--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -19,7 +19,7 @@
             <div class="detail-stock-container">
                 <div class="detail-left-panel">
                     <section class="detail-stock-header">
-                        <img src="" alt="삼성전자">
+                        <img src="" alt="">
                         <div class="detail-text-col">
                             <div>
                                 <h2 class="detail-stock-name">

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -2,6 +2,8 @@
    메인 페이지 JavaScript (com.antmillion.main.js)
    =========================== */
 
+
+
 var subscribedTopics = {}; // 구독한 토픽 저장 {stockCode: subscription}
 
 // STOMP 연결 (수정 버전)
@@ -340,6 +342,9 @@ function initializeMissionButton() {
 // 일별 분봉 조회 - 차트
 let stockChart = null;
 let candleSeries = null;
+let currentCandleData = null; // 추가: 현재 진행 중인 캔들
+let lastCandleUpdateTime = null; // 추가: 마지막 캔들 업데이트 시간
+let currentChartStockCode = null; // 추가: 현재 차트에 표시 중인 종목 코드
 
 // 시간 포맷 변환 함수
 function formatToTimestamp(dateStr, timeStr) {
@@ -360,6 +365,11 @@ function drawStockMinuteChart(stockCode) {
     const chartContainer = document.getElementById('main-stockChart');
     if (!chartContainer) return;
     chartContainer.innerHTML = ''; // 기존 차트가 있다면 삭제
+
+    currentChartStockCode = stockCode;
+
+    currentCandleData = null;
+    lastCandleUpdateTime = null;
 
     stockChart = LightweightCharts.createChart(chartContainer, {
         width: chartContainer.clientWidth,
@@ -432,10 +442,58 @@ function drawStockMinuteChart(stockCode) {
         
         if (chartData.length > 0) {
             candleSeries.setData(chartData);
+
+            currentCandleData = chartData[chartData.length - 1];
+            lastCandleUpdateTime = currentCandleData.time;
+
             stockChart.timeScale().fitContent();
         }
     })
     .catch(err => console.error("API 호출 에러:", err));
+}
+
+// ========== 실시간 현재가로 차트 캔들 업데이트 ==========
+function updateMainChartRealtime(currentPrice) {
+    // 차트가 없거나, 초기 캔들 데이터가 없으면 종료
+    if (!candleSeries || !currentCandleData) return;
+
+    const currentTimestamp = getCurrentMinuteTimestamp();
+
+    // 새로운 분이 시작되면 새 캔들 생성
+    if (currentTimestamp !== lastCandleUpdateTime) {
+        console.log('새로운 분 시작 - 새 캔들 생성');
+
+        currentCandleData = {
+            time: currentTimestamp,
+            open: currentPrice,
+            high: currentPrice,
+            low: currentPrice,
+            close: currentPrice
+        };
+        lastCandleUpdateTime = currentTimestamp;
+
+        // 새 캔들 추가
+        candleSeries.update(currentCandleData);
+    }
+    // 같은 분 내에서는 기존 캔들 업데이트
+    else {
+        currentCandleData.close = currentPrice;
+        currentCandleData.high = Math.max(currentCandleData.high, currentPrice);
+        currentCandleData.low = Math.min(currentCandleData.low, currentPrice);
+
+        // 기존 캔들 업데이트
+        candleSeries.update(currentCandleData);
+    }
+}
+
+// ========== 현재 분의 timestamp 계산 ==========
+function getCurrentMinuteTimestamp() {
+    const now = new Date();
+    now.setSeconds(0);
+    now.setMilliseconds(0);
+
+    const offsetInSeconds = now.getTimezoneOffset() * 60;
+    return Math.floor(now.getTime() / 1000) - offsetInSeconds;
 }
 
 // 마우스 오버 이벤트
@@ -453,6 +511,11 @@ document.addEventListener('mouseover', (e) => {
             if (codeEl.textContent !== stockCode) {
                 nameEl.textContent = stockName;
                 codeEl.textContent = stockCode;
+
+                // 차트 전환 시 캔들 데이터 초기화
+                currentCandleData = null;
+                lastCandleUpdateTime = null;
+
                 drawStockMinuteChart(stockCode);
             }
         }
@@ -531,10 +594,15 @@ function updateStockRealtimePrice(stockCode, tradeData) {
     if (!stockItem) return;
 
     // 현재가 업데이트
+    const currentPrice = Number(tradeData.stckPrpr);
     const priceElement = stockItem.querySelector('.main-stocklist-price');
     if (priceElement) {
-        const price = Number(tradeData.stckPrpr).toLocaleString('ko-KR') + '원';
+        const price = currentPrice.toLocaleString('ko-KR') + '원';
         priceElement.textContent = price;
+    }
+
+    if (currentChartStockCode === stockCode) {
+        updateMainChartRealtime(currentPrice);
     }
 
     // 등락률 업데이트 (main-stocklist-change가 등락률을 표시한다고 가정)

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -5,6 +5,11 @@ if (typeof contextPath === 'undefined') {
     console.log('[contextPath 설정]', contextPath);
 }
 
+// ==== 차트 관련 전역 변수 ====
+let currentCandleData = null; // 현재 진행 중인 캔들 데이터
+let lastCandleUpdateTime = null; // 마지막 캔들 업데이트 시간
+let currentChartPeriod = 'minute';
+
 // STOMP 관련 변수
 let stompClient = null;
 let subscribedTopics = {}; // 구독한 토픽 저장 {stockCode: subscription}
@@ -111,7 +116,8 @@ function updateStockRealtimePrice(stockCode, tradeData) {
     
     // 현재가 업데이트
     lastRealtimePrice = rawPrice;
-    const formattedPrice = Number(rawPrice).toLocaleString('ko-KR') + '원';
+    const currentPrice = Number(rawPrice);
+    const formattedPrice = currentPrice.toLocaleString('ko-KR') + '원';
 
     const currentPriceH3 = document.getElementById('detail-current-price-h3');
     if (currentPriceH3) {
@@ -123,6 +129,9 @@ function updateStockRealtimePrice(stockCode, tradeData) {
         const orderPriceElem = document.getElementById('order-display-price');
         if (orderPriceElem) orderPriceElem.textContent = formattedPrice;
     }
+
+    // 차트에 실시간 현재가 반영
+    updateChartRealtime(currentPrice);
     
     // 매수/매도 비율 및 텍스트 업데이트
     const rawBuyRate = tradeData.shnuRate;
@@ -518,6 +527,8 @@ function drawDetailChart(stockCode) {
         wickDownColor: '#3498db'
     });
 
+    currentChartPeriod = 'minute';
+
     // API 호출
     fetch(`/antmillion/api/kis/stream/${stockCode}`)
     .then(res => res.json())
@@ -556,10 +567,126 @@ function drawDetailChart(stockCode) {
         
         if (chartData.length > 0) {
             candleSeries.setData(chartData);
+
+            // 마지막 캔들을 현재 진행 중인 캔들로 설정
+            currentCandleData = chartData[chartData.length - 1];
+            lastCandleUpdateTime = currentCandleData.time;
+
             stockChart.timeScale().fitContent();
         }
     })
     .catch(err => console.error("API 호출 에러:", err));
+}
+
+// ========== 실시간 현재가로 차트 캔들 업데이트 ==========
+function updateChartRealtime(currentPrice) {
+    if (!candleSeries || !currentCandleData) return;
+
+    let currentTime;
+
+    // 기간별로 현재 시간 계산
+    if (currentChartPeriod === 'minute') {
+        currentTime = getCurrentMinuteTimestamp();
+    } else {
+        currentTime = getCurrentPeriodTime(currentChartPeriod);
+    }
+
+    // 새로운 기간이 시작되면 새 캔들 생성
+    const lastTime = getCanonicalTime(lastCandleUpdateTime, currentChartPeriod);
+    const nowTime = getCanonicalTime(currentTime, currentChartPeriod);
+
+    // 새로운 분이 시작되면 새 캔들 생성
+    if (nowTime !== lastTime) {
+        console.log('새로운 분 시작 - 새 캔들 생성');
+
+        currentCandleData = {
+            time: currentTime,
+            open: currentPrice,
+            high: currentPrice,
+            low: currentPrice,
+            close: currentPrice
+        };
+        lastCandleUpdateTime = currentTime;
+
+        // 새 캔들 추가
+        candleSeries.update(currentCandleData);
+    }
+    // 같은 분 내에서는 기존 캔들 업데이트
+    else {
+        currentCandleData.close = currentPrice;
+        currentCandleData.high = Math.max(currentCandleData.high, currentPrice);
+        currentCandleData.low = Math.min(currentCandleData.low, currentPrice);
+
+        // 기존 캔들 업데이트
+        candleSeries.update(currentCandleData);
+        console.log('캔들 업데이트:', currentCandleData);
+    }
+}
+
+// ========== 현재 분의 timestamp 계산 (초는 0으로) ==========
+function getCurrentMinuteTimestamp() {
+    const now = new Date();
+    now.setSeconds(0);
+    now.setMilliseconds(0);
+
+    const offsetInSeconds = now.getTimezoneOffset() * 60;
+    return Math.floor(now.getTime() / 1000) - offsetInSeconds;
+}
+
+// ========== 일/주/월/년봉용: 현재 기간의 시간 계산 ==========
+function getCurrentPeriodTime(period) {
+    const now = new Date();
+
+    if (period === 'D') {
+        // 일봉: 오늘 날짜
+        return {
+            year: now.getFullYear(),
+            month: now.getMonth() + 1,
+            day: now.getDate()
+        };
+    } else if (period === 'W') {
+        // 주봉: 이번 주 월요일 날짜
+        const monday = new Date(now);
+        const day = now.getDay();
+        const diff = day === 0 ? -6 : 1 - day; // 일요일이면 -6, 아니면 월요일까지 차이
+        monday.setDate(now.getDate() + diff);
+
+        return {
+            year: monday.getFullYear(),
+            month: monday.getMonth() + 1,
+            day: monday.getDate()
+        };
+    } else if (period === 'M') {
+        // 월봉: 이번 달 1일
+        return {
+            year: now.getFullYear(),
+            month: now.getMonth() + 1,
+            day: 1
+        };
+    } else if (period === 'Y') {
+        // 연봉: 올해 1월 1일
+        return {
+            year: now.getFullYear(),
+            month: 1,
+            day: 1
+        };
+    }
+
+    return null;
+}
+
+// ========== 기간별 정규화된 시간 반환 (비교용) ==========
+function getCanonicalTime(time, period) {
+    if (period === 'minute') {
+        // 분봉은 timestamp를 그대로 사용
+        return time;
+    } else {
+        // 일/주/월/년봉은 {year, month, day} 객체를 문자열로 변환
+        if (typeof time === 'object') {
+            return `${time.year}-${String(time.month).padStart(2, '0')}-${String(time.day).padStart(2, '0')}`;
+        }
+        return time;
+    }
 }
 
 // 날짜 포맷 변경 (main.js의 formatDate 함수와 동일)
@@ -611,6 +738,8 @@ function drawPeriodChart(stockCode, period) {
         wickDownColor: '#3498db'
     });
 
+    currentChartPeriod = period;
+
     // API 호출
     fetch(`/antmillion/api/kis/periodChart/${stockCode}?period=${period}`)
         .then(res => res.json())
@@ -634,6 +763,11 @@ function drawPeriodChart(stockCode, period) {
 
             if (chartData.length > 0) {
                 candleSeries.setData(chartData);
+
+                // 마지막 캔들 저장
+                currentCandleData = chartData[chartData.length - 1];
+                lastCandleUpdateTime = getCanonicalTime(currentCandleData.time, period);
+
                 stockChart.timeScale().fitContent();
             }
         })
@@ -660,6 +794,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.classList.add('detail-period-active');
 
                 const period = this.getAttribute('data-period');
+
+                // 차트 전환 시 currentCandleData 초기화
+                currentCandleData = null;
+                lastCandleUpdateTime = null;
 
                 if (period === 'minute') {
                     // 분봉 차트


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #187 

---

### 📝 작업 내용
- 종목 상세 페이지의 종목 차트에 실시간 현재가를 반영하였습니다. 분/일/주/월/년 차트 모두 가장 최근 캔들이 실시간 현재가를 나타냅니다.
- 메인 페이지의 종목 항목에 마우스를 올리면 나오는 차트에 실시간 현재가를 반영하였습니다.

---

### 📷 스크린샷 (선택)

<img width="940" height="428" alt="image" src="https://github.com/user-attachments/assets/eb2ab6b2-d67e-4bad-a626-c0900c38bb71" />

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
