### PR TITLE
Refactor: 등락률, 거래비율 bar의 기본값 및 장마감 시 표시 변경

### DIFF
--- a/src/main/java/com/antmillion/kis/dto/StockVolumeRank.java
+++ b/src/main/java/com/antmillion/kis/dto/StockVolumeRank.java
@@ -17,6 +17,8 @@ public class StockVolumeRank {
     private String presentPrice; //주식 현재가
     @JsonProperty("acml_vol")
     private String acmVolume; //누적 거래량
+    @JsonProperty("prdy_ctrt")
+    private String prdyCtrt; //전일 대비율
 
     private Boolean isFavorite = false;
 }

--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -109,17 +109,15 @@
                         </div>
                     </div>
                     <div class="detail-sentiment-section">
-                        <div class="detail-sentiment-text">
-                            🔥 현재 투자자 <span id="sentiment-percent">50</span>%가 <span class="detail-red-text" id="sentiment-direction">매수</span>쪽으로 몰려요!
-                        </div>
+                        <div class="detail-sentiment-text"><span>정규 장 시간(09:00~15:30)에 확인할 수 있어요</span></div>
                         <div class="detail-percent-labels">
-                            <div style="width: 50%;" id="buy-percent">50%</div>
-                            <div style="width: 50%;" id="sell-percent">50%</div>
+                            <div style="width: 50%;" id="buy-percent"></div>
+                            <div style="width: 50%;" id="sell-percent"></div>
                         </div>
                         <div>
                             <div class="detail-progress-bar">
-                                <div class="detail-fill-buy" style="width: 50%;" id="buy-bar"></div>
-                                <div class="detail-fill-sell" style="width: 50%;" id="sell-bar"></div>
+                                <div class="detail-fill-buy detail-sentiment-inactive" style="width: 50%;" id="buy-bar"></div>
+                                <div class="detail-fill-sell detail-sentiment-inactive" style="width: 50%;" id="sell-bar"></div>
                             </div>
                         </div>
                     </div>

--- a/src/main/webapp/WEB-INF/views/stock/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/stock/detail.jsp
@@ -109,7 +109,7 @@
                         </div>
                     </div>
                     <div class="detail-sentiment-section">
-                        <div class="detail-sentiment-text"><span>정규 장 시간(09:00~15:30)에 확인할 수 있어요</span></div>
+                        <div class="detail-sentiment-text"><span>장 시간에 확인할 수 있어요</span></div>
                         <div class="detail-percent-labels">
                             <div style="width: 50%;" id="buy-percent"></div>
                             <div style="width: 50%;" id="sell-percent"></div>

--- a/src/main/webapp/resources/css/main/main.css
+++ b/src/main/webapp/resources/css/main/main.css
@@ -588,6 +588,10 @@ body {
     background-color: rgb(237, 244, 253);
 }
 
+.main-sentiment-inactive {
+    background-color: #e0e0e0 !important;
+}
+
 .main-stocklist-sentiment {
     display: flex;
     flex-direction: column;

--- a/src/main/webapp/resources/css/stock/detail.css
+++ b/src/main/webapp/resources/css/stock/detail.css
@@ -329,6 +329,11 @@ body {
     text-align: center;
 }
 
+/* 거래 비율 비활성 상태 (회색) */
+.detail-sentiment-inactive {
+    background-color: #e0e0e0 !important;
+}
+
 .detail-red-text { color: var(--color-positive); }
 
 .detail-blue-text { color: var(--color-negative); }

--- a/src/main/webapp/resources/css/stocklist/stocklist.css
+++ b/src/main/webapp/resources/css/stocklist/stocklist.css
@@ -319,6 +319,10 @@ body {
     white-space: nowrap;
 }
 
+.stocklist-sentiment-inactive {
+    background-color: #e0e0e0 !important;;
+}
+
 .stocklist-sentiment-bar {
     display: flex;
     width: 100px;

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -39,6 +39,21 @@ function createMainStockItemHTML(stock, index) {
     const favoriteIcon = stock.isFavorite ? '♥' : '♡';
     const favoriteClass = stock.isFavorite ? 'active' : '';
     const currentPrice = Number(stock.stck_prpr).toLocaleString('ko-KR') + '원';
+    let changeText = '0.00%';
+    let changeClass = '';
+
+    if (stock.prdy_ctrt) {
+        const changeValue = parseFloat(stock.prdy_ctrt);
+        if (changeValue > 0) {
+            changeText = '+' + changeValue + '%';
+            changeClass = 'positive';
+        } else if (changeValue < 0) {
+            changeText = changeValue + '%';
+            changeClass = 'negative';
+        } else {
+            changeText = changeValue + '%';
+        }
+    }
 
     return `
         <div class="main-stocklist-item" data-id="${stock.mksc_shrn_iscd}">
@@ -53,15 +68,15 @@ function createMainStockItemHTML(stock, index) {
                 <span class="main-stocklist-name">${stock.hts_kor_isnm}</span>
             </div>
             <div class="main-stocklist-price">${currentPrice}</div>
-            <div class="main-stocklist-change">0.00%</div>
+            <div class="main-stocklist-change ${changeClass}">${changeText}</div>
             <div class="main-stocklist-sentiment">
                 <div class="main-stocklist-sentiment-bar">
-                    <div class="main-stocklist-sentiment-buy" style="width: 50%;"></div>
-                    <div class="main-stocklist-sentiment-sell" style="width: 50%;"></div>
+                    <div class="main-stocklist-sentiment-buy main-sentiment-inactive" style="width: 50%;"></div>
+                    <div class="main-stocklist-sentiment-sell main-sentiment-inactive" style="width: 50%;"></div>
                 </div>
                 <div class="main-stocklist-sentiment-labels">
-                    <span class="main-stocklist-sentiment-buy-label">50</span>
-                    <span class="main-stocklist-sentiment-sell-label">50</span>
+                    <span class="main-stocklist-sentiment-buy-label"></span>
+                    <span class="main-stocklist-sentiment-sell-label"></span>
                 </div>
             </div>
         </div>
@@ -643,6 +658,9 @@ function updateStockRealtimePrice(stockCode, tradeData) {
         const sellLabel = stockItem.querySelector('.main-stocklist-sentiment-sell-label');
 
         if (buyBar && sellBar) {
+            buyBar.classList.remove('main-sentiment-inactive');
+            sellBar.classList.remove('main-sentiment-inactive');
+
             buyBar.style.width = buyRate + '%';
             sellBar.style.width = sellRate + '%';
         }

--- a/src/main/webapp/resources/js/main/main.js
+++ b/src/main/webapp/resources/js/main/main.js
@@ -219,6 +219,7 @@ function attachMainStockItemListeners() {
 
 // DOM이 로드되면 초기화
 document.addEventListener('DOMContentLoaded', function() {
+    scheduleMarketClose();
     initializeMainPage();
 });
 
@@ -827,3 +828,62 @@ function disableMockMode() {
 // 브라우저 콘솔에서 사용 가능하도록 전역으로 노출
 window.enableMockMode = enableMockMode;
 window.disableMockMode = disableMockMode;
+
+// ========== 거래 비율 초기 상태로 복원 ==========
+function resetSentimentToDefault() {
+    console.log('[main.js] 모든 종목의 거래 비율을 초기 상태로 복원');
+
+    const stockItems = document.querySelectorAll('.main-stocklist-item');
+
+    stockItems.forEach(item => {
+        const buyBar = item.querySelector('.main-stocklist-sentiment-buy');
+        const sellBar = item.querySelector('.main-stocklist-sentiment-sell');
+        const buyLabel = item.querySelector('.main-stocklist-sentiment-buy-label');
+        const sellLabel = item.querySelector('.main-stocklist-sentiment-sell-label');
+
+        if (buyBar && sellBar) {
+            buyBar.classList.add('main-sentiment-inactive');
+            sellBar.classList.add('main-sentiment-inactive');
+            buyBar.style.width = '50%';
+            sellBar.style.width = '50%';
+        }
+
+        if (buyLabel) buyLabel.textContent = '';
+        if (sellLabel) sellLabel.textContent = '';
+    });
+}
+
+// ========== 15:30, 20:00에 자동 실행 예약 ==========
+function scheduleMarketClose() {
+    const now = new Date();
+
+    // 15:30 예약
+    const today1530 = new Date(now);
+    today1530.setHours(15, 30, 0, 0);
+    const msUntil1530 = today1530 - now;
+
+    if (msUntil1530 > 0) {
+        console.log(`[main.js] 15:30까지 ${Math.floor(msUntil1530 / 1000 / 60)}분 남음`);
+        setTimeout(() => {
+            console.log('[main.js] 15:30 정규장 마감 - 기본값으로 전환');
+            resetSentimentToDefault();
+        }, msUntil1530);
+    } else {
+        console.log('[main.js] 오늘 15:30은 이미 지났습니다.');
+    }
+
+    // 20:00 예약
+    const today2000 = new Date(now);
+    today2000.setHours(20, 0, 0, 0);
+    const msUntil2000 = today2000 - now;
+
+    if (msUntil2000 > 0) {
+        console.log(`[main.js] 20:00까지 ${Math.floor(msUntil2000 / 1000 / 60)}분 남음`);
+        setTimeout(() => {
+            console.log('[main.js] 20:00 시간외 마감 - 기본값으로 전환');
+            resetSentimentToDefault();
+        }, msUntil2000);
+    } else {
+        console.log('[main.js] 오늘 20:00은 이미 지났습니다.');
+    }
+}

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -146,24 +146,19 @@ function updateStockRealtimePrice(stockCode, tradeData) {
         const buyBar = document.getElementById('buy-bar');
         const sellBar = document.getElementById('sell-bar');
         if (buyBar && sellBar) {
+            buyBar.classList.remove('detail-sentiment-inactive');
+            sellBar.classList.remove('detail-sentiment-inactive');
+
             buyBar.style.width = buyRate + '%';
             sellBar.style.width = sellRate + '%';
         }
-    
-        const sentimentPercent = document.getElementById('sentiment-percent');
-        const sentimentDir = document.getElementById('sentiment-direction');
-    
-        if (sentimentPercent && sentimentDir) {
-            // 매수가 50% 이상이면 '매수', 아니면 '매도' 표시
-            if (buyRate >= 50) {
-                sentimentPercent.textContent = buyRate;
-                sentimentDir.textContent = '매수';
-                sentimentDir.className = 'detail-red-text'; // 빨간색
-            } else {
-                sentimentPercent.textContent = sellRate;
-                sentimentDir.textContent = '매도';
-                sentimentDir.className = 'detail-blue-text'; // 파란색
-            }
+
+        const sentimentText = document.querySelector('.detail-sentiment-text');
+        // 매수가 50% 이상이면 '매수', 아니면 '매도' 표시
+        if (buyRate >= 50) {
+            sentimentText.innerHTML = `🔥 현재 투자자 <span id="sentiment-percent">${buyRate}</span>%가 <span class="detail-red-text" id="sentiment-direction">매수</span>쪽으로 몰려요!`;
+        } else {
+            sentimentText.innerHTML = `🔥 현재 투자자 <span id="sentiment-percent">${sellRate}</span>%가 <span class="detail-blue-text" id="sentiment-direction">매도</span>쪽으로 몰려요!`;
         }
         
         const buyText = document.getElementById('buy-percent');

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -774,6 +774,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const urlParams = new URLSearchParams(window.location.search);
     const stockCode = urlParams.get('code'); // ?code=005930 에서 005930 추출
 
+    scheduleMarketClose();
+
     initPriceTypeEvents();
     if (stockCode) {
         drawDetailChart(stockCode);
@@ -1771,3 +1773,63 @@ window.checkMockStatus = checkMockStatus;
     
     console.log('=== 주문 UI 초기화 완료 ===');
 })();
+
+// ========== 거래 비율 초기 상태로 복원 ==========
+function resetSentimentToDefault() {
+    console.log('거래 비율을 초기 상태로 복원');
+
+    const sentimentText = document.querySelector('.detail-sentiment-text');
+    const buyBar = document.getElementById('buy-bar');
+    const sellBar = document.getElementById('sell-bar');
+    const buyPercent = document.getElementById('buy-percent');
+    const sellPercent = document.getElementById('sell-percent');
+
+    if (sentimentText) {
+        sentimentText.innerHTML = '<span>장 시간에 확인할 수 있어요</span>';
+    }
+
+    if (buyBar && sellBar) {
+        buyBar.classList.add('detail-sentiment-inactive');
+        sellBar.classList.add('detail-sentiment-inactive');
+        buyBar.style.width = '50%';
+        sellBar.style.width = '50%';
+    }
+
+    if (buyPercent) buyPercent.textContent = '';
+    if (sellPercent) sellPercent.textContent = '';
+}
+
+// ========== 특정 시간에 자동 실행 예약 ==========
+function scheduleMarketClose() {
+    const now = new Date();
+
+    // ✅ 15:30 예약
+    const today1530 = new Date(now);
+    today1530.setHours(15, 30, 0, 0);
+    const msUntil1530 = today1530 - now;
+
+    if (msUntil1530 > 0) {
+        console.log(`15:30까지 ${Math.floor(msUntil1530 / 1000 / 60)}분 남음`);
+        setTimeout(() => {
+            console.log('15:30 정규장 마감 - 기본값으로 전환');
+            resetSentimentToDefault();
+        }, msUntil1530);
+    } else {
+        console.log('오늘 15:30은 이미 지났습니다.');
+    }
+
+    // ✅ 20:00 예약
+    const today2000 = new Date(now);
+    today2000.setHours(20, 0, 0, 0);
+    const msUntil2000 = today2000 - now;
+
+    if (msUntil2000 > 0) {
+        console.log(`20:00까지 ${Math.floor(msUntil2000 / 1000 / 60)}분 남음`);
+        setTimeout(() => {
+            console.log('20:00 시간외 마감 - 기본값으로 전환');
+            resetSentimentToDefault();
+        }, msUntil2000);
+    } else {
+        console.log('오늘 20:00은 이미 지났습니다.');
+    }
+}

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -143,6 +143,9 @@ function updateStockRealtimePrice(stockCode, tradeData) {
         const sellLabel = stockItem.querySelector('.stocklist-sentiment-sell-label');
 
         if (buyBar && sellBar) {
+            buyBar.classList.remove('stocklist-sentiment-inactive');
+            sellBar.classList.remove('stocklist-sentiment-inactive');
+
             buyBar.style.width = buyRate + '%';
             sellBar.style.width = sellRate + '%';
         }
@@ -195,10 +198,21 @@ function createStockItemHTML(stock, index, isFavorite) {
     const currentPrice = Number(stock.stck_prpr || 0).toLocaleString('ko-KR') + '원';
 
     // 등락률 계산
-    const priceChange = Number(stock.prdy_vrss || 0);
-    const changeRate = Number(stock.prdy_ctrt || 0);
-    const changeSign = priceChange > 0 ? '+' : (priceChange < 0 ? '-' : '');
-    const changeClass = priceChange > 0 ? 'positive' : (priceChange < 0 ? 'negative' : '');
+    let changeText = '0.00%';
+    let changeClass = '';
+
+    if (stock.prdy_ctrt) {
+        const changeValue = parseFloat(stock.prdy_ctrt);
+        if (changeValue > 0) {
+            changeText = '+' + changeValue + '%';
+            changeClass = 'positive';
+        } else if (changeValue < 0) {
+            changeText = changeValue + '%';
+            changeClass = 'negative';
+        } else {
+            changeText = changeValue + '%';
+        }
+    }
 
     return `
         <div class="stocklist-item" data-code="${stock.mksc_shrn_iscd}">
@@ -214,15 +228,15 @@ function createStockItemHTML(stock, index, isFavorite) {
                 <span class="stocklist-name">${stock.hts_kor_isnm}</span>
             </div>
             <div class="stocklist-price">${currentPrice}</div>
-            <div class="stocklist-change ${changeClass}">${changeSign}${Math.abs(changeRate).toFixed(2)}%</div>
+            <div class="stocklist-change ${changeClass}">${changeText}</div>
             <div class="stocklist-sentiment">
                 <div class="stocklist-sentiment-bar">
-                    <div class="stocklist-sentiment-buy" style="width: 50%;"></div>
-                    <div class="stocklist-sentiment-sell" style="width: 50%;"></div>
+                    <div class="stocklist-sentiment-buy stocklist-sentiment-inactive" style="width: 50%;"></div>
+                    <div class="stocklist-sentiment-sell stocklist-sentiment-inactive" style="width: 50%;"></div>
                 </div>
                 <div class="stocklist-sentiment-labels">
-                    <span class="stocklist-sentiment-buy-label">50</span>
-                    <span class="stocklist-sentiment-sell-label">50</span>
+                    <span class="stocklist-sentiment-buy-label"></span>
+                    <span class="stocklist-sentiment-sell-label"></span>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/resources/js/stocklist/stocklist.js
+++ b/src/main/webapp/resources/js/stocklist/stocklist.js
@@ -478,6 +478,8 @@ window.addEventListener('pagehide', function(e) {
 
 // ========== 초기화 ==========
 document.addEventListener('DOMContentLoaded', function() {
+    scheduleMarketClose();
+    
     // STOMP 연결
     connectStomp();
 
@@ -597,3 +599,62 @@ function checkMockStatus() {
 window.enableMockMode = enableMockMode;
 window.disableMockMode = disableMockMode;
 window.checkMockStatus = checkMockStatus;
+
+// ========== 거래 비율 초기 상태로 복원 ==========
+function resetSentimentToDefault() {
+    console.log('[stocklist.js] 모든 종목의 거래 비율을 초기 상태로 복원');
+
+    const stockItems = document.querySelectorAll('.stocklist-item');
+
+    stockItems.forEach(item => {
+        const buyBar = item.querySelector('.stocklist-sentiment-buy');
+        const sellBar = item.querySelector('.stocklist-sentiment-sell');
+        const buyLabel = item.querySelector('.stocklist-sentiment-buy-label');
+        const sellLabel = item.querySelector('.stocklist-sentiment-sell-label');
+
+        if (buyBar && sellBar) {
+            buyBar.classList.add('stocklist-sentiment-inactive');
+            sellBar.classList.add('stocklist-sentiment-inactive');
+            buyBar.style.width = '50%';
+            sellBar.style.width = '50%';
+        }
+
+        if (buyLabel) buyLabel.textContent = '';
+        if (sellLabel) sellLabel.textContent = '';
+    });
+}
+
+// ========== 15:30, 20:00에 자동 실행 예약 ==========
+function scheduleMarketClose() {
+    const now = new Date();
+
+    // 15:30 예약
+    const today1530 = new Date(now);
+    today1530.setHours(15, 30, 0, 0);
+    const msUntil1530 = today1530 - now;
+
+    if (msUntil1530 > 0) {
+        console.log(`[stocklist.js] 15:30까지 ${Math.floor(msUntil1530 / 1000 / 60)}분 남음`);
+        setTimeout(() => {
+            console.log('[stocklist.js] 15:30 정규장 마감 - 기본값으로 전환');
+            resetSentimentToDefault();
+        }, msUntil1530);
+    } else {
+        console.log('[stocklist.js] 오늘 15:30은 이미 지났습니다.');
+    }
+
+    // 20:00 예약
+    const today2000 = new Date(now);
+    today2000.setHours(20, 0, 0, 0);
+    const msUntil2000 = today2000 - now;
+
+    if (msUntil2000 > 0) {
+        console.log(`[stocklist.js] 20:00까지 ${Math.floor(msUntil2000 / 1000 / 60)}분 남음`);
+        setTimeout(() => {
+            console.log('[stocklist.js] 20:00 시간외 마감 - 기본값으로 전환');
+            resetSentimentToDefault();
+        }, msUntil2000);
+    } else {
+        console.log('[stocklist.js] 오늘 20:00은 이미 지났습니다.');
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #193 

---

### 📝 작업 내용
- 메인화면, 종목리스트 화면, 종목 상세 화면에서 등락률, 거래비율의 기본값을 변경하였습니다. 등락률은 거래량순위 api에서 얻은 전일 대비율을 그대로 사용하고, 거래 비율은 거래가 없으므로 회색 bar가 나타나게 하였습니다. 장 시간에 실시간 데이터를 받게 되면 받는 데이터로 표시됩니다.
- '장 시간 -> 장 마감'  시점에 자동으로 기본값으로 전환됩니다.

---

### 📷 스크린샷 (선택)
장 마감 후 메인
<img width="761" height="499" alt="스크린샷 2026-01-27 200355" src="https://github.com/user-attachments/assets/4990b258-0020-46d7-9bf6-e59bf52850f5" />

장 마감 후 종목리스트
<img width="1564" height="690" alt="스크린샷 2026-01-27 200404" src="https://github.com/user-attachments/assets/6bc43d93-2d9d-49c7-b27b-5ac6d6868844" />

장 시간 중 종목 상세
<img width="322" height="105" alt="스크린샷 2026-01-27 195843" src="https://github.com/user-attachments/assets/7f13dd64-8c29-4140-9a63-d0f552cc2857" />

장 마감 후 종목 상세
<img width="331" height="76" alt="스크린샷 2026-01-27 200345" src="https://github.com/user-attachments/assets/0d8f752d-5af0-43f9-8aff-ce09380864ea" />



---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
