### PR TITLE
Refactor: 매수/매도 쿼리를 수정하여 마이너스 수량 문제 개선

### DIFF
--- a/src/main/java/com/antmillion/stock/mapper/AssetMapper.java
+++ b/src/main/java/com/antmillion/stock/mapper/AssetMapper.java
@@ -8,7 +8,7 @@ import org.apache.ibatis.annotations.Update;
 
 @Mapper
 public interface AssetMapper {
-    
+   
     /**
      * 특정 계좌의 특정 종목 보유 수량 조회 (합산)
      */
@@ -17,31 +17,32 @@ public interface AssetMapper {
             "WHERE account_id = #{accountId} AND stock_code = #{stockCode}")
     Integer getQuantityByAccountAndStock(@Param("accountId") Long accountId, 
                                          @Param("stockCode") String stockCode);
-    
+	
     /**
-     * 자산 추가 (신규 매수)
-     */
-    @Insert("INSERT INTO asset (account_id, stock_code, quantity, avg_price, purchase_amount, updated_at) " +
-            "VALUES (#{accountId}, #{stockCode}, #{quantity}, #{avgPrice}, #{purchaseAmount}, NOW())")
-    int insertAsset(@Param("accountId") Long accountId,
-                    @Param("stockCode") String stockCode,
-                    @Param("quantity") Integer quantity,
-                    @Param("avgPrice") Integer avgPrice,
-                    @Param("purchaseAmount") Long purchaseAmount);
-    
-    /**
-     * 자산 수량 감소 (매도)
-     * 가장 오래된 자산부터 차감
-     */
-    @Update("UPDATE asset " +
-            "SET quantity = quantity - #{quantity}, " +
-            "    updated_at = NOW() " +
-            "WHERE account_id = #{accountId} " +
-            "AND stock_code = #{stockCode} " +
-            "AND quantity > 0 " +
-            "ORDER BY updated_at ASC " +
-            "LIMIT 1")
-    int decreaseAssetQuantity(@Param("accountId") Long accountId,
-                              @Param("stockCode") String stockCode,
-                              @Param("quantity") Integer quantity);
+	 * [매수 정합성] UPSERT: 수량 증가, 단가 갱신
+	 */
+	@Insert("INSERT INTO asset (account_id, stock_code, quantity, purchase_amount, avg_price, updated_at) " +
+	        "VALUES (#{accountId}, #{stockCode}, #{quantity}, #{purchaseAmount}, #{avgPrice}, NOW()) " +
+	        "ON DUPLICATE KEY UPDATE " +
+	        "   avg_price = (purchase_amount + VALUES(purchase_amount)) / (quantity + VALUES(quantity)), " +
+	        "   quantity = quantity + VALUES(quantity), " +
+	        "   purchase_amount = purchase_amount + VALUES(purchase_amount), " +
+	        "   updated_at = NOW()")
+	int upsertAssetBuy(@Param("accountId") Long accountId, 
+	                   @Param("stockCode") String stockCode, 
+	                   @Param("quantity") Integer quantity, 
+	                   @Param("avgPrice") Integer avgPrice, 
+	                   @Param("purchaseAmount") Long purchaseAmount);
+
+	/**
+	 * [매도 정합성] UPDATE: 수량 감소, 총액 감소 (단가는 유지)
+	 */
+	@Update("UPDATE asset SET " +
+	        "   quantity = quantity - #{quantity}, " +
+	        "   purchase_amount = purchase_amount - (avg_price * #{quantity}), " +
+	        "   updated_at = NOW() " +
+	        "WHERE account_id = #{accountId} AND stock_code = #{stockCode} AND quantity >= #{quantity}")
+	int updateAssetSell(@Param("accountId") Long accountId, 
+	                    @Param("stockCode") String stockCode, 
+	                    @Param("quantity") Integer quantity);
 }

--- a/src/main/java/com/antmillion/stock/service/StockOrderService.java
+++ b/src/main/java/com/antmillion/stock/service/StockOrderService.java
@@ -66,31 +66,28 @@ public class StockOrderService {
         
         // 4. 잔액 및 자산 업데이트
         if ("BUY".equals(transactionType)) {
-            // 매수: 잔액 차감
+            // [자산 업데이트]
+            assetMapper.upsertAssetBuy(accountId, stockCode, quantity, orderPrice, totalPrice);
+            
+            // [잔액 업데이트]
             long newBalance = account.getBalance() - totalPrice;
-            accountMapper.updateBalance(accountId, newBalance);
-            log.info("잔액 차감: {} → {}", account.getBalance(), newBalance);
+            accountMapper.updateBalance(accountId, newBalance); 
             
-            // 자산 추가
-            assetMapper.insertAsset(accountId, stockCode, quantity, orderPrice, totalPrice);
-            log.info("자산 추가: {} 종목 {} 주 매수", stockCode, quantity);
-            
+            log.info("매수 완료: 잔액 {} → {}", account.getBalance(), newBalance);
+
         } else if ("SELL".equals(transactionType)) {
-            // 매도: 잔액 증가
+            // [자산 업데이트]
+            int rows = assetMapper.updateAssetSell(accountId, stockCode, quantity);
+            
+            if (rows == 0) {
+                throw new IllegalArgumentException("보유 수량이 부족하여 매도할 수 없습니다.");
+            }
+            
+            // [잔액 업데이트]
             long newBalance = account.getBalance() + totalPrice;
             accountMapper.updateBalance(accountId, newBalance);
-            log.info("잔액 증가: {} → {}", account.getBalance(), newBalance);
             
-            // 자산 차감
-            int remaining = quantity;
-            while (remaining > 0) {
-                int decreased = assetMapper.decreaseAssetQuantity(accountId, stockCode, remaining);
-                if (decreased == 0) {
-                    break; // 더 이상 차감할 자산 없음
-                }
-                remaining -= decreased;
-            }
-            log.info("자산 차감: {} 종목 {} 주 매도", stockCode, quantity);
+            log.info("매도 완료: 잔액 {} → {}", account.getBalance(), newBalance);
         }
         
         return result > 0;


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #199 

---

### 📝 작업 내용
- account_id와 stock_code를 유니크 키로 설정하여 중복 배제
- 동일 종목 매수 시 데이터가 여러 줄로 생성되던 정합성 오류 해결

---

### 📷 스크린샷 (선택)
<img width="765" height="862" alt="image" src="https://github.com/user-attachments/assets/aa1665f9-5339-4733-a40b-5faf5783aafb" />

<img width="1245" height="358" alt="image" src="https://github.com/user-attachments/assets/77fdcf3d-3654-43b1-9fb9-dce1247c1a91" />
아래처럼 계좌 당 종목 코드가 유일하도록 개선합니다.

<img width="1216" height="240" alt="image" src="https://github.com/user-attachments/assets/29bac7b8-b852-4f88-acee-6b6d978bf377" />


---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [x] PR 제목 규칙을 지켰다
- [x] 추가/수정 사항을 설명했다
- [x] 이슈 번호를 연결했다
