### PR TITLE
Refactor: FOMO 편향 체크 로직 실시간 데이터 연동 및 현재가 목데이터 제거

### DIFF
--- a/src/main/java/com/antmillion/history/controller/BiasAlertController.java
+++ b/src/main/java/com/antmillion/history/controller/BiasAlertController.java
@@ -100,11 +100,12 @@ public class BiasAlertController {
     public ResponseEntity<BiasAlertDTO> checkFomo(
             @RequestParam(required = false, defaultValue = "1") Long accountId,
             @RequestParam(required = false, defaultValue = "1") Long userId,
-            @RequestParam String stockCode) {
+            @RequestParam String stockCode,
+            @RequestParam(required = false) java.math.BigDecimal changeRate) {
 
-        System.out.println("BiasAlertController: FOMO 체크 - accountId=" + accountId + ", userId=" + userId + ", stockCode=" + stockCode);
+        System.out.println("BiasAlertController: FOMO 체크 - accountId=" + accountId + ", userId=" + userId + ", stockCode=" + stockCode + ", changeRate=" + changeRate);
 
-        BiasAlertDTO result = biasAlertService.checkFomoBias(accountId, stockCode, userId);
+        BiasAlertDTO result = biasAlertService.checkFomoBias(accountId, stockCode, userId, changeRate);
 
         if (result == null) {
             System.out.println("결과: 조회 실패 (204 No Content)");

--- a/src/main/java/com/antmillion/history/service/BiasAlertService.java
+++ b/src/main/java/com/antmillion/history/service/BiasAlertService.java
@@ -17,6 +17,9 @@ import com.antmillion.history.mapper.HistoryMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.antmillion.kis.dto.CurrentPriceRequest;
+import com.antmillion.kis.service.KisApiService;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -24,6 +27,7 @@ public class BiasAlertService {
 
 	    private final BiasAlertMapper biasAlertMapper;
 	    private final HistoryMapper historyMapper;
+	    private final KisApiService kisApiService;
 
     // 위험회피 편향 기준
     private static final BigDecimal RISK_AVERSION_PROFIT_THRESHOLD = new BigDecimal("3.0");
@@ -54,8 +58,13 @@ public class BiasAlertService {
             return null;
         }
 
-        // 2. 현재가 조회
-        BigDecimal currentPrice = biasAlertMapper.selectCurrentPrice(stockCode);
+        // 2. 현재가 조회 (실시간)
+        CurrentPriceRequest priceRequest = CurrentPriceRequest.builder()
+                .marketCode("J")
+                .stockCode(stockCode)
+                .build();
+        long currentPriceRaw = kisApiService.getCurrentPrice(priceRequest);
+        BigDecimal currentPrice = BigDecimal.valueOf(currentPriceRaw);
 
         // 3. 수익률 계산
         BigDecimal profitRate = calculateProfitRate(asset.getAvgPrice(), currentPrice);
@@ -105,8 +114,13 @@ public class BiasAlertService {
             return null;
         }
 
-        // 2. 현재가 조회
-        BigDecimal currentPrice = biasAlertMapper.selectCurrentPrice(stockCode);
+        // 2. 현재가 조회 (실시간)
+        CurrentPriceRequest priceRequest = CurrentPriceRequest.builder()
+                .marketCode("J")
+                .stockCode(stockCode)
+                .build();
+        long currentPriceRaw = kisApiService.getCurrentPrice(priceRequest);
+        BigDecimal currentPrice = BigDecimal.valueOf(currentPriceRaw);
 
         // 3. 수익률 계산
         BigDecimal profitRate = calculateProfitRate(asset.getAvgPrice(), currentPrice);
@@ -160,8 +174,13 @@ public class BiasAlertService {
             return null;
         }
 
-        // 2. 현재가 조회
-        BigDecimal currentPrice = biasAlertMapper.selectCurrentPrice(stockCode);
+        // 2. 현재가 조회 (실시간)
+        CurrentPriceRequest priceRequest = CurrentPriceRequest.builder()
+                .marketCode("J")
+                .stockCode(stockCode)
+                .build();
+        long currentPriceRaw = kisApiService.getCurrentPrice(priceRequest);
+        BigDecimal currentPrice = BigDecimal.valueOf(currentPriceRaw);
 
         // 3. 수익률 계산
         BigDecimal profitRate = calculateProfitRate(asset.getAvgPrice(), currentPrice);
@@ -201,15 +220,24 @@ public class BiasAlertService {
      * 조건: 당일 등락률 +20% 이상
      * 타이밍: 페이지 로드(상시) + 매수 탭 전환 시
      */
-    public BiasAlertDTO checkFomoBias(Long accountId, String stockCode, Long userId) {
-        log.info("FOMO 체크 시작 - accountId={}, stockCode={}, userId={}", accountId, stockCode, userId);
+    public BiasAlertDTO checkFomoBias(Long accountId, String stockCode, Long userId, BigDecimal changeRate) {
+        log.info("FOMO 체크 시작 - accountId={}, stockCode={}, userId={}, changeRate={}", accountId, stockCode, userId, changeRate);
 
-        // 1. 당일 등락률 조회
-        BigDecimal changeRate = biasAlertMapper.selectDailyChangeRate(stockCode);
-        log.info("당일 등락률: {}%", changeRate);
+        // 1. 등락률 확인 (파라미터가 없으면 DB에서 조회)
+        if (changeRate == null) {
+            changeRate = biasAlertMapper.selectDailyChangeRate(stockCode);
+            log.info("DB에서 등락률 조회: {}%", changeRate);
+        } else {
+            log.info("프론트에서 전달받은 등락률: {}%", changeRate);
+        }
 
-        // 2. 현재가 조회 (종목명 표시용)
-        BigDecimal currentPrice = biasAlertMapper.selectCurrentPrice(stockCode);
+        // 2. 현재가 조회 (실시간)
+        CurrentPriceRequest priceRequest = CurrentPriceRequest.builder()
+                .marketCode("J")
+                .stockCode(stockCode)
+                .build();
+        long currentPriceRaw = kisApiService.getCurrentPrice(priceRequest);
+        BigDecimal currentPrice = BigDecimal.valueOf(currentPriceRaw);
 
         // 3. 편향 조건 체크: 등락률 +20% 이상
         boolean hasAlert = changeRate.compareTo(FOMO_SURGE_THRESHOLD) >= 0;

--- a/src/main/resources/mappers/history/BiasAlertMapper.xml
+++ b/src/main/resources/mappers/history/BiasAlertMapper.xml
@@ -13,6 +13,7 @@
         <result property="holdingDays" column="holdingDays"/>
     </resultMap>
 
+    <!-- asset 테이블에서 보유 주식 조회 -->
     <select id="selectAssetForBiasCheck" resultMap="BiasAlertResultMap">
         SELECT 
             a.stock_code AS stockCode,
@@ -30,17 +31,6 @@
         LIMIT 1
     </select>
     
-    <!-- 현재가 조회 -->
-    <select id="selectCurrentPrice" resultType="java.math.BigDecimal">
-        SELECT 
-            CASE 
-                WHEN #{stockCode} = '005930' THEN 72100.00
-                WHEN #{stockCode} = '000660' THEN 47430.00
-                WHEN #{stockCode} = '035720' THEN 47430.00
-                ELSE 50000.00
-            END AS currentPrice
-    </select>
-    
     <!-- 최근 5거래일간 매도 이력 체크 (손실회피용) -->
     <select id="checkRecentSellHistory" resultType="boolean">
         SELECT 
@@ -54,18 +44,6 @@
           AND transaction_type = 'SELL'
           AND status = 'COMPLETED'
           AND created_at >= DATE_SUB(NOW(), INTERVAL 5 DAY)
-    </select>
-    
-    <!-- 당일 등락률 조회 (FOMO용) -->
-    <select id="selectDailyChangeRate" resultType="java.math.BigDecimal">
-        SELECT 
-            CASE 
-                WHEN #{stockCode} = '005930' THEN 2.5
-                WHEN #{stockCode} = '000660' THEN -3.2
-                WHEN #{stockCode} = '035720' THEN -5.1
-                WHEN #{stockCode} = '005380' THEN 25.5
-                ELSE 0.0
-            END AS changeRate
     </select>
         
 </mapper>

--- a/src/main/webapp/resources/js/stock/detail.js
+++ b/src/main/webapp/resources/js/stock/detail.js
@@ -100,6 +100,11 @@ function subscribeStockTopic(stockCode) {
 
         // 화면 업데이트
         updateStockRealtimePrice(stockCode, tradeData);
+        
+        // FOMO 실시간 체크
+        const changeRate = parseFloat(tradeData.prdyCtrt || 0);
+        window.lastFomoChangeRate = changeRate;
+        checkFomoInRealtime(changeRate);
     });
 
     subscribedTopics[stockCode] = subscription;
@@ -426,11 +431,11 @@ async function checkSunkCostAlert(stockCode) {
 }
 
 // FOMO 체크 함수
-async function checkFomoAlert(stockCode) {
-    console.log('[FOMO API 호출] stockCode:', stockCode);
+async function checkFomoAlert(stockCode, changeRate) {
+    console.log('[FOMO API 호출] stockCode:', stockCode, 'changeRate:', changeRate);
     
     try {
-        const url = contextPath + '/api/bias-alert/check-fomo?stockCode=' + stockCode;
+        const url = contextPath + '/api/bias-alert/check-fomo?stockCode=' + stockCode + '&changeRate=' + changeRate;
         console.log('[FOMO API URL]', url);
         
         const response = await fetch(url);
@@ -854,7 +859,9 @@ document.addEventListener('DOMContentLoaded', async function() {
             const lossData = await checkLossAversionAlert(stockCode);
             
             // 우선순위 4: FOMO
-            const fomoData = await checkFomoAlert(stockCode);
+            // FOMO는 WebSocket 데이터 수신 대기 (0.5초)
+            await new Promise(resolve => setTimeout(resolve, 500));
+            const fomoData = await checkFomoAlert(stockCode, window.lastFomoChangeRate || 0);
             
             // 우선순위에 따라 표시 (매몰비용 > 손실회피 > FOMO)
             if (sunkCostData && sunkCostData.hasAlert) {
@@ -959,7 +966,9 @@ document.addEventListener('DOMContentLoaded', async function() {
                         const lossData = await checkLossAversionAlert(stockCode);
                         
                         // 우선순위 4: FOMO
-                        const fomoData = await checkFomoAlert(stockCode);
+                        // FOMO는 WebSocket 데이터 수신 대기 (0.5초)
+            await new Promise(resolve => setTimeout(resolve, 500));
+            const fomoData = await checkFomoAlert(stockCode, window.lastFomoChangeRate || 0);
                         
                         if (sunkCostData && sunkCostData.hasAlert) {
                             console.log('[매수 탭] 매몰비용 경고: ' + sunkCostData.stockName + ' ' + sunkCostData.profitRate + '% 손실, ' + sunkCostData.holdingDays + '일 보유');
@@ -993,6 +1002,12 @@ document.addEventListener('DOMContentLoaded', async function() {
                             }
                         } else {
                             console.log('[매수 탭] 편향 조건 미달');
+                        }
+                        
+                        // ✅ 실시간 체크도 활성화 (이미 20% 이상이면 표시)
+                        if (window.lastFomoChangeRate >= 20 && !fomoAlertShown) {
+                            console.log('[매수 탭] 실시간 등락률 20% 이상 - 경고 표시');
+                            checkFomoInRealtime(window.lastFomoChangeRate);
                         }
                     } catch (error) {
                         console.error('[매수 탭] 편향 체크 에러:', error);
@@ -1834,5 +1849,42 @@ function scheduleMarketClose() {
         }, msUntil2000);
     } else {
         console.log('오늘 20:00은 이미 지났습니다.');
+    }
+}
+
+
+// FOMO 실시간 체크
+let fomoAlertShown = false;
+let fomoConditionMet = false;
+let fomoCheckTimeout = null;
+
+async function checkFomoInRealtime(changeRate) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const stockCode = urlParams.get('code');
+    if (!stockCode) return;
+    
+    if (changeRate >= 20) {
+        fomoConditionMet = true;
+        const buyTab = document.querySelector('[data-type="buy"]');
+        const isBuyTab = buyTab && buyTab.classList.contains('detail-tab-active');
+        
+        if (!fomoAlertShown && isBuyTab) {
+            if (fomoCheckTimeout) clearTimeout(fomoCheckTimeout);
+            fomoCheckTimeout = setTimeout(async () => {
+                const data = await checkFomoAlert(stockCode, changeRate);
+                if (data && data.hasAlert) {
+                    if (typeof showBiasAlert === 'function') {
+                        showBiasAlert('FOMO');
+                        fomoAlertShown = true;
+                    }
+                    if (typeof checkUnreadAlerts === 'function') {
+                        setTimeout(() => { checkUnreadAlerts(); }, 0);
+                    }
+                }
+            }, 500);
+        }
+    } else {
+        fomoConditionMet = false;
+        fomoAlertShown = false;
     }
 }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #206 

---

### 📝 작업 내용
FOMO 편향 체크 로직에서 사용되던 하드코딩(Mock) 등락률 및 현재가 데이터 제거
XML Mapper 및 Service 로직을 수정하여 실시간 DB 기반 등락률/현재가 데이터를 사용하도록 개선
주식 상세 화면(detail.js)에서 실시간 데이터 기준 FOMO 경고 알림이 정상 동작하도록 연동
기존에는 가짜 데이터로 인해 실제 시장 상황(20% 이상 급등 등)이 알림 로직에 반영되지 않았으나,
이번 작업으로 실제 시장 데이터 기반의 FOMO 경고가 정확히 발생하도록 개선되었습니다.

### 📷 스크린샷 (선택)
-- 1. 네이버 수정 (손실회피 테스트용)
-- 평균가를 높여서 -7% 손실 만들기
-- 현재가 277,000원 기준 → 평균가 300,000원이면 -7.67%
INSERT INTO asset (
    account_id,
    stock_code,
    quantity,
    purchase_amount,
    avg_price,
    updated_at
)
VALUES (
    1,
    '035420',
    3,
    900000,          -- 300,000 * 3
    300000.00,       -- 평균가 (손실회피 테스트)
    DATE_SUB(NOW(), INTERVAL 10 DAY)
);

-- 2. 셀트리온 수정 (매몰비용 테스트용)
-- 평균가를 높여서 -10% 손실 만들기
-- 현재가 217,500원 기준 → 평균가 245,000원이면 -11.22%
INSERT INTO asset (
    account_id,
    stock_code,
    quantity,
    purchase_amount,
    avg_price,
    updated_at
)
VALUES (
    1,
    '068270',
    4,
    980000,          -- 245,000 * 4
    245000.00,       -- 평균가 (매몰비용 테스트)
    DATE_SUB(NOW(), INTERVAL 25 DAY)
);

테스트 하고싶으면 db에 이거 넣고 네이버 셀트리온 종목 가보면 경고창 뜹니다! fomo 경고창은 등락률 기준 20%이상 들어가면 뜹니다!

### 💬 리뷰 요구사항 (선택)


## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
