### PR TITLE
Feat: 접근 토큰 중복 방지를 위한 Redisson 분산 락 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,13 @@
 		<jjwt.version>0.11.5</jjwt.version>
 	</properties>
 	<dependencies>
+		<!-- Redisson (Spring Legacy용) -->
+		<dependency>
+			<groupId>org.redisson</groupId>
+			<artifactId>redisson</artifactId>
+			<version>3.23.5</version>
+		</dependency>
+
 	   <!-- WebSocket -->
 	    <dependency>
 		    <groupId>org.springframework</groupId>

--- a/src/main/java/com/antmillion/kis/service/KisApiService.java
+++ b/src/main/java/com/antmillion/kis/service/KisApiService.java
@@ -10,6 +10,8 @@ import com.antmillion.kis.repository.KisMarketIndexChartRedisRepository;
 import com.antmillion.kis.repository.KisStockVolumeRankRedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -27,6 +29,7 @@ import java.util.Optional;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -41,6 +44,8 @@ public class KisApiService {
     private final KisMarketIndexChartRedisRepository kisMarketIndexChartRepository;
     private final KisStockVolumeRankRedisRepository kisStockVolumeRankRedisRepository;
 
+    private final RedissonClient redissonClient;
+
     /**
      * KIS 액세스 토큰 조회/발급
      * Redis에 유효한 토큰이 있으면 반환, 없으면 신규 발급 후 Redis에 저장
@@ -53,17 +58,54 @@ public class KisApiService {
             return saved.get();
         }
 
-        // 신규 발급
-        log.info("토큰 신규 발급");
-        KisAccessTokenResponse response = issueAccessTokenAPI();
+        // 분산 락 획득
+        RLock lock = redissonClient.getLock("kis:token:lock");
 
-        // Redis 저장 (TTL 자동 설정)
-        kisAccessTokenRedisRepository.save(
-                response.getAccessToken(),
-                response.getExpiresIn()
-        );
+        try {
+            // 락 획득 시도: 최대 5초 대기, 획득 후 10초간 유지
+            boolean isLocked = lock.tryLock(5, 10, TimeUnit.SECONDS);
 
-        return response.getAccessToken();
+            if (!isLocked) {
+                log.warn("토큰 발급 락 획득 실패 - 다른 스레드가 발급 중");
+                // 락 획득 실패 시 재시도 (다른 스레드가 발급 완료 후 저장했을 가능성)
+                Thread.sleep(100); // 짧은 대기
+                Optional<String> retried = kisAccessTokenRedisRepository.findAccessToken();
+                if (retried.isPresent()) {
+                    log.info("다른 스레드가 발급한 토큰 사용");
+                    return retried.get();
+                }
+                throw new RuntimeException("토큰 발급 락 획득 실패");
+            }
+
+            // 2차 체크: 락 획득 후 다시 한 번 Redis 확인 (Double-Checked Locking)
+            Optional<String> doubleChecked = kisAccessTokenRedisRepository.findAccessToken();
+            if (doubleChecked.isPresent()) {
+                log.info("락 획득 후 확인: 기존 토큰 재사용");
+                return doubleChecked.get();
+            }
+
+            // 신규 발급
+            log.info("토큰 신규 발급");
+            KisAccessTokenResponse response = issueAccessTokenAPI();
+
+            // Redis 저장 (TTL 자동 설정)
+            kisAccessTokenRedisRepository.save(
+                    response.getAccessToken(),
+                    response.getExpiresIn()
+            );
+            log.info("토큰 신규 발급 완료 및 저장");
+            return response.getAccessToken();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("토큰 발급 중 인터럽트 발생", e);
+            throw new RuntimeException("토큰 발급 중 인터럽트 발생", e);
+        } finally {
+            // 락 해제
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("토큰 발급 락 해제");
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/antmillion/redisson/RedissonConfig.java
+++ b/src/main/java/com/antmillion/redisson/RedissonConfig.java
@@ -1,0 +1,29 @@
+package com.antmillion.redisson;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${redis.host}")
+    private String redisHost;
+
+    @Value("${redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + redisHost + ":" + redisPort)
+                .setConnectionPoolSize(50)
+                .setConnectionMinimumIdleSize(10);
+
+        return Redisson.create(config);
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #214 

---

### 📝 작업 내용
- 한국투자증권 api 접근 토큰 발급 메소드 getKisAccessToken 에 Redisson 분산 락을 적용하였습니다.
- 접근 토큰을 얻으려는 시도가 동시에 여러번 있더라도, 락이 걸려 한번만 발급되고 나머지는 redis에서 재사용하게 됩니다.
- Redisson 분산 락 관련 참고 자료입니다.   [Redisson 분산락을 사용하는 이유와 기본적인 사용 방법](https://wildeveloperetrain.tistory.com/280#google_vignette)

```mermaid
flowchart TD
    A[토큰 요청] --> B{Redis에<br/>토큰 존재?}
    B -->|"있음"| C[기존 토큰 반환]
    B -->|"없음"| D[Redisson Lock 획득 시도<br/>10초 대기, 10초 유지]
    
    D -->|"Lock 획득 실패"| E[100ms 대기]
    E --> F{Redis 재확인}
    F -->|"토큰 있음<br/>(다른 스레드 발급)"| G[발급된 토큰 사용]
    F -->|"토큰 없음(네트워크 지연 등)"| H[Exception 발생]
    
    D -->|"Lock 획득 성공"| I[Double-Checked Locking<br/>Redis 2차 확인]
    I -->|"토큰 있음"| J[기존 토큰 반환<br/>Lock 해제]
    I -->|"토큰 없음"| K[한국투자증권 API 호출<br/>신규 토큰 발급]
    K --> L[Redis 저장<br/>TTL 자동 설정]
    L --> M[Lock 해제]
    M --> N[신규 토큰 반환]
    
    style D fill:#ff9999
    style I fill:#ffcc99
    style K fill:#99ccff
    style L fill:#99ff99
```

---

### 📷 스크린샷 (선택)
메인 화면 접근 시 로그
<img width="475" height="263" alt="image" src="https://github.com/user-attachments/assets/9b9b05df-fb97-465d-92a3-21470263bea1" />
최초 접근 스레드가 락을 건 후 토큰을 발급 받아 redis 저장 후 락 해제하면, 다른 스레드들은 redis에 이미 저장된 것 재사용

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
