### PR TITLE
Refactor: 동기화 될 종목 정보 수정 및 거래량 순위 api 수정

### DIFF
--- a/src/main/java/com/antmillion/kis/controller/KisController.java
+++ b/src/main/java/com/antmillion/kis/controller/KisController.java
@@ -136,9 +136,9 @@ public class KisController {
                 .screenCode("20171") //고정
                 .inputCode("0000") //고정 : 종목코드 전체
                 .divClassCode("0") //고정 : 전체 (보통주, 우선주)
-                .blngClassCode("0") //고정 : 평균거래량
+                .blngClassCode("3") //고정 : 거래대금액순
                 .targetClassCode("111111111") //고정
-                .targetExlsClassCode("0000001100") //고정 : ETF, ETN 제외
+                .targetExlsClassCode("0000000000") //고정
                 .inputPrice1("0") //고정 : 전체 가격 대상
                 .inputPrice2("0") //고정 : 전체 가격 대상
                 .volumeCount("0") //고정 : 전체 거래량 대상

--- a/src/main/java/com/antmillion/stock/service/KisStockSyncService.java
+++ b/src/main/java/com/antmillion/stock/service/KisStockSyncService.java
@@ -164,19 +164,10 @@ public class KisStockSyncService {
                     continue;
                 }
 
-                // 코스피: ST 그룹만 허용
-                if ("KOSPI".equals(marketType)) {
-                    String groupCode = part2.substring(0, 3).trim();
-                    if (!"ST".equals(groupCode)) {
-                        continue;
-                    }
-                }
-
-                // 코스닥: 스팩 제외
-                if ("KOSDAQ".equals(marketType)) {
-                    if (koreanName.contains("스팩") || koreanName.contains("SPAC")) {
-                        continue;
-                    }
+                // EW (ELW) 제외
+                String groupCode = part2.substring(0, 3).trim();
+                if ("EW".equals(groupCode)) {
+                    continue;
                 }
 
                 result.add(StockDTO.builder()

--- a/src/main/webapp/WEB-INF/views/main/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main/main.jsp
@@ -127,7 +127,7 @@
                 <!-- 주식 테이블 -->
                 <div class="main-stock-table-card">
                     <div class="main-stocklist-header">
-                        <div class="main-stocklist-time">거래량 순위·오늘 09:27 기준</div>
+                        <div class="main-stocklist-time">거래대금 순위·오늘 <%= new java.text.SimpleDateFormat("HH:mm").format(new java.util.Date()) %> 기준</div>
                     </div>
                     <div class="main-stocklist-table-header">
                         <div class="main-stocklist-header-cell"></div>

--- a/src/main/webapp/WEB-INF/views/stocklist/stocklist.jsp
+++ b/src/main/webapp/WEB-INF/views/stocklist/stocklist.jsp
@@ -23,7 +23,7 @@
                 <button class="stocklist-tab-btn">관심종목</button>
             </div>
             <div class="stocklist-header">
-                <div class="stocklist-time">거래량 순위·오늘 09:27 기준</div>
+                <div class="stocklist-time">거래대금 순위·오늘 <%= new java.text.SimpleDateFormat("HH:mm").format(new java.util.Date()) %> 기준</div>
                 <div class="stocklist-view-options">
                     <span class="stocklist-help-icon">?</span>
                 </div>


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #216 

---

### 📝 작업 내용
- 종목 동기화를 할 때, 코스피에서 ELW 를 제외한 전 종목을 포함하도록 변경하였습니다.
- 거래량 순위 api를 통해 받게 되는 데이터를 거래량순이 아닌 거래대금순으로 변경하였습니다.
- 종목 리스트(main.jsp, stocklist.jsp)의 테이블 위 라벨을 '거래대금 순위'로 수정하였습니다. 시간은 현재 시간으로 표시됩니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
