### PR TITLE
Refactor: 메인 페이지 오늘의 미션 카드 개편 및 통합 로직 적용

### DIFF
--- a/src/main/java/com/antmillion/mission/controller/MissionController.java
+++ b/src/main/java/com/antmillion/mission/controller/MissionController.java
@@ -71,7 +71,6 @@ public class MissionController {
     @ResponseBody
     public Map<String, Object> getTodayMissionStatus() {
         Long userId = missionService.getCurrentUserId();
-        int solvedCount = missionService.getTodaySolvedCount(userId);
-        return Map.of("solvedCount", solvedCount);
+        return missionService.getTodayMissionStatus(userId);
     }
 }

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -6,6 +6,7 @@ import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
 import com.antmillion.user.dto.UserRankResponseDTO;
 
 import java.util.List;
+import java.util.Map;
 
 public interface MissionService {
     List<QuizQuestionResponseDTO> getDailyQuiz();
@@ -13,5 +14,5 @@ public interface MissionService {
     UserRankResponseDTO getUserMissionStatus(Long userId);
     Long getCurrentUserId();
     boolean isTodayMissionCompleted(Long userId);
-    int getTodaySolvedCount(Long userId);
+    Map<String, Object> getTodayMissionStatus(Long userId);
 }

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -162,8 +162,10 @@ public class MissionServiceImpl implements MissionService {
     }
 
     public boolean isTodayMissionCompleted(Long userId) {
-        int solvedCount = missionMapper.countTodaySolvedQuiz(userId);
-        return solvedCount >= 2;
+        Map<String, Object> status = getTodayMissionStatus(userId);
+        // totalProgress가 100이면 완료로 간주
+        int progress = (int)status.get("totalProgress");
+        return progress >= 100;
     }
 
     public Map<String, Object> getTodayMissionStatus(Long userId) {

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -3,6 +3,7 @@ package com.antmillion.mission.service;
 import com.antmillion.auth.mapper.MemberMapper;
 import com.antmillion.mission.dto.*;
 import com.antmillion.mission.mapper.MissionMapper;
+import com.antmillion.news.mapper.NewsMapper;
 import com.antmillion.user.dto.UserRankResponseDTO;
 import com.antmillion.user.service.AntRankService;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -24,6 +26,7 @@ public class MissionServiceImpl implements MissionService {
     private final MissionMapper missionMapper;
     private final MemberMapper memberMapper;
     private final AntRankService antRankService;
+    private final NewsMapper newsMapper;
 
     // 로그인한 유저 ID를 가져오는 메서드
     public Long getCurrentUserId() {
@@ -163,7 +166,37 @@ public class MissionServiceImpl implements MissionService {
         return solvedCount >= 2;
     }
 
-    public int getTodaySolvedCount(Long userId) {
-        return missionMapper.countTodaySolvedQuiz(userId);
+    public Map<String, Object> getTodayMissionStatus(Long userId) {
+        Map<String, Object> status = new HashMap<>();
+
+        if (userId == null) {
+            status.put("totalProgress", 0);
+            return status;
+        }
+
+        // 퀴즈 진행 상황
+        int solvedQuizCount = missionMapper.countTodaySolvedQuiz(userId);
+        int quizGoal = 2;
+
+        // 뉴스 진행 상황
+        int readNewsCount = newsMapper.countTodayNewsRead(userId);
+        int newsGoal = 5;
+
+        // 전체 달성률 계산
+        // 분자: (푼 퀴즈 수 + 읽은 뉴스 수)
+        int currentTotal = solvedQuizCount + readNewsCount;
+        // 분모: (퀴즈 목표 2 + 뉴스 목표 5) = 7
+        int goalTotal = quizGoal + newsGoal;
+
+        int totalProgress = (int) ((double) currentTotal / goalTotal * 100);
+        totalProgress = Math.min(totalProgress, 100); // 100% 넘지 않게
+
+        // 데이터 담기
+        status.put("totalProgress", totalProgress);
+        status.put("quizCount", solvedQuizCount);
+        status.put("newsCount", readNewsCount);
+        status.put("isQuizCompleted", solvedQuizCount >= quizGoal);
+        status.put("isNewsCompleted", readNewsCount >= newsGoal);
+        return status;
     }
 }

--- a/src/main/java/com/antmillion/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/antmillion/news/service/NewsServiceImpl.java
@@ -1,5 +1,6 @@
 package com.antmillion.news.service;
 
+import com.antmillion.auth.mapper.MemberMapper;
 import com.antmillion.news.dto.NewsLogDTO;
 import com.antmillion.news.mapper.NewsMapper;
 import lombok.RequiredArgsConstructor;
@@ -15,12 +16,14 @@ import java.util.Map;
 public class NewsServiceImpl implements NewsService {
 
     private final NewsMapper newsMapper;
+    private final MemberMapper memberMapper;
 
     // 뉴스 클릭 처리 및 현재 달성률 반환
     @Transactional
     public Map<String, Object> readNews(Long userId, String newsUrl) {
         // 중복 체크 (오늘 이미 읽은 기사인지)
         boolean alreadyRead = newsMapper.existsTodayLog(userId, newsUrl);
+        int earnedPoint = 0; // 뉴스 획득 포인트
 
         if (!alreadyRead) {
             // 안 읽었으면 기록 저장
@@ -29,10 +32,21 @@ public class NewsServiceImpl implements NewsService {
                     .newsUrl(newsUrl)
                     .build();
             newsMapper.insertNewsLog(newsLogDTO);
+
+            // 오늘 읽은 뉴스 개수 조회
+            int count = newsMapper.countTodayNewsRead(userId);
+
+            // 5회 이하일 때만 포인트 지급
+            if (count <= 5) {
+                earnedPoint = 100;
+                memberMapper.updateUserPoint(userId, earnedPoint);
+            }
         }
 
-        // 달성률 계산 (읽은 후 카운트 다시 조회)
-        return getMissionProgress(userId);
+        // 5. 달성률 계산 및 결과 반환
+        Map<String, Object> response = getMissionProgress(userId);
+        response.put("earnedPoint", earnedPoint); // 화면에 포인트 적립 알림 띄우기 위해 추가
+        return response;
     }
 
     // 현재 미션 달성률 조회 (페이지 로딩용)

--- a/src/main/resources/mappers/news/NewsMapper.xml
+++ b/src/main/resources/mappers/news/NewsMapper.xml
@@ -27,7 +27,8 @@
         SELECT news_url
         FROM news_log
         WHERE user_id = #{userId}
-          AND DATE(news_read_at) = CURDATE()
+        AND DATE(news_read_at) = CURDATE()
+        ORDER BY news_read_at ASC
     </select>
 
 </mapper>

--- a/src/main/webapp/WEB-INF/views/main/main.jsp
+++ b/src/main/webapp/WEB-INF/views/main/main.jsp
@@ -90,9 +90,11 @@
             <!-- 미션 카드 -->
             <div class="main-mission-card main-grid-mission">
                 <div class="main-mission-header">
-                    <h3>미션 : 오늘의 경제 퀴즈 풀기</h3>
+                    <h3>오늘의 미션</h3>
                 </div>
-                <p class="main-mission-description">OX 퀴즈 맞히고 100P 받아가세요!</p>
+                <p class="main-mission-description">퀴즈 풀고 뉴스 읽으면
+                    <strong>하루 최대 700P</strong> 획득할 수 있어요!<br>지금 당장 나의 개미 랭크를 높여보세요!
+                </p>
                 <c:choose>
                     <c:when test="${missionCompleted}">
                         <span class="main-mission-completed-button">미션완료</span>

--- a/src/main/webapp/WEB-INF/views/mission/mission.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/mission.jsp
@@ -36,7 +36,9 @@
                 <!-- 미션 1: 경제 퀴즈 풀기 -->
                 <div class="mission-card" id="mission-card-quiz">
                     <div class="mission-card-header">
-                        <h3 class="mission-card-title">미션 1. 오늘의 경제 퀴즈 풀기</h3>
+                        <h3 class="mission-card-title">미션 1. 오늘의 경제 퀴즈 풀기
+                            <span id="quiz-count-text" style="color: #2970ff; font-size: 0.9em;">(0/2)</span>
+                        </h3>
                     </div>
                     <div class="mission-card-body">
                         <p class="mission-card-description">매일 2문제, 정답을 맞히면 <b>문제당 100P!</b><br>
@@ -50,10 +52,12 @@
                 <!-- 미션 2: 경제 뉴스 읽기 -->
                 <div class="mission-card" id="mission-card-news">
                     <div class="mission-card-header">
-                        <h3 class="mission-card-title">미션 2. 오늘의 증권 뉴스 읽기</h3>
+                        <h3 class="mission-card-title">미션 2. 오늘의 증권 뉴스 읽기
+                            <span id="news-count-text" style="color: #2970ff; font-size: 0.9em;">(0/5)</span>
+                        </h3>
                     </div>
                     <div class="mission-card-body">
-                        <p class="mission-card-description">최신 증권 뉴스를 확인하고 <b>기사당 20P</b> 획득!<br>
+                        <p class="mission-card-description">최신 증권 뉴스를 확인하고 <b>기사당 100P</b> 획득!<br>
                             하루 5번, 시장의 흐름을 읽으면 포인트가 쌓입니다.</p>
                     </div>
                     <div class="mission-card-footer">

--- a/src/main/webapp/WEB-INF/views/mission/quiz.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/quiz.jsp
@@ -19,7 +19,7 @@
 			<!-- 진행률 카드 -->
 			<div class="quiz-progress-card">
 				<div class="quiz-progress-header">
-					<h2 class="quiz-progress-title">오늘의 미션 달성률</h2>
+					<h2 class="quiz-progress-title">오늘의 경제 퀴즈 달성률</h2>
 					<div class="quiz-progress-status" id="quiz-progressStatus">0%
 						달성!</div>
 				</div>

--- a/src/main/webapp/resources/css/main/main.css
+++ b/src/main/webapp/resources/css/main/main.css
@@ -232,7 +232,8 @@ body {
 }
 
 .main-mission-description {
-    font-size: 13px;
+    align-items: center;
+    font-size: 15px;
     color: var(--text-secondary);
     margin-bottom: 12px;
     line-height: 1.5;
@@ -241,16 +242,16 @@ body {
 
 .main-mission-button {
     width: 100%;
-    padding: 10px 20px;
-    background: linear-gradient(135deg, #FF3366 0%, #FF6B9D 100%);
-    color: white;
-    border: none;
-    border-radius: 10px;
+    padding: 12px 20px;
     font-size: 14px;
     font-weight: 600;
     font-family: var(--font-korean);
+    background-color: #e8f1ff;
+    color: #2970ff;
+    border-radius: 12px;
+    border: none;
     cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: all 0.2s ease;
 }
 
 .main-mission-completed-button {
@@ -267,11 +268,6 @@ body {
     align-items: center;
     justify-content: center;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.main-mission-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(255, 51, 102, 0.3);
 }
 
 .main-mission-button:active {

--- a/src/main/webapp/resources/css/mission/quiz.css
+++ b/src/main/webapp/resources/css/mission/quiz.css
@@ -338,16 +338,14 @@ body {
 }
 
 .quiz-points-message {
+	background: linear-gradient(135deg, #ffd700 0%, #ffed4e 100%);
+	color: #8b6914;
 	display: block;
-	background: linear-gradient(135deg, #2970ff 0%, #1e5dd8 100%);
-	color: white;
-	padding: 10px 10px;
-	border-radius: 50px;
+	padding: 6px 12px;
+	border-radius: 10px;
 	font-size: 14px;
 	font-weight: 600;
-	box-shadow: 0 4px 12px rgba(41, 112, 255, 0.3);
-	margin-bottom: 20px;
-	position: static;
+	margin-bottom: 10px;
 	animation: bounceIn 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 

--- a/src/main/webapp/resources/css/news/news.css
+++ b/src/main/webapp/resources/css/news/news.css
@@ -106,7 +106,7 @@ body {
 .news-section-card {
     background: var(--secondary-bg);
     border-radius: 20px;
-    padding: 28px;
+    padding: 24px;
     box-shadow: var(--shadow-sm);
     border: 1px solid var(--border-color);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -128,6 +128,16 @@ body {
     letter-spacing: -0.5px;
     animation: fadeInUp 0.5s cubic-bezier(0.4, 0, 0.2, 1) backwards;
     animation-delay: 0.1s;
+}
+
+.news-points-badge {
+    background: linear-gradient(135deg, #ffd700 0%, #ffed4e 100%);
+    color: #8b6914;
+    padding: 6px 12px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 600;
+    animation: bounceIn 0.5s cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
 
 .news-cards-container {

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -27,17 +27,42 @@ function checkMissionStatus() {
         url: cpath + '/mission/today-status',
         method: 'GET',
         success: function(data) {
-            const solvedCount = data.solvedCount || 0;
-            const progressPercent = (solvedCount / 2) * 100;
+            // 전체 진행률 업데이트 (서버에서 계산된 totalProgress 사용)
+            const progress = data.totalProgress || 0;
 
-            $('#mission-progressBar').css('width', progressPercent + '%');
-            $('#mission-progressStatus').text(Math.round(progressPercent) + '% 달성!');
+            $('#mission-progressBar').css('width', progress + '%');
+            $('#mission-progressStatus').text(progress + '% 달성!');
 
-            // 퀴즈 완료 상태 표시
-            if (solvedCount > 1) {
-                $('#mission-card-quiz').addClass('completed');
-                $('#quiz-start-btn').text('완료됨');
-                $('#quiz-start-btn').removeAttr('onclick');
+            // 퀴즈: (푼 개수 / 2)
+            const quizCount = data.quizCount || 0;
+            $('#quiz-count-text').text(`(${quizCount}/2)`);
+
+            // 뉴스: (읽은 개수 / 5)
+            const newsCount = data.newsCount || 0;
+            $('#news-count-text').text(`(${newsCount}/5)`);
+
+            // 퀴즈 미션 카드 상태 업데이트
+            if (data.isQuizCompleted) {
+                const $quizCard = $('#mission-card-quiz');
+                $quizCard.addClass('completed');
+
+                // 버튼 비활성화 및 텍스트 변경
+                const $quizBtn = $('#quiz-start-btn');
+                $quizBtn.text('완료됨');
+                $quizBtn.prop('disabled', true);
+                $quizBtn.removeAttr('onclick'); // 클릭 이벤트 제거
+            }
+
+            // 뉴스 미션 카드 상태 업데이트
+            if (data.isNewsCompleted) {
+                const $newsCard = $('#mission-card-news');
+                $newsCard.addClass('completed');
+
+                // 버튼 비활성화 및 텍스트 변경
+                const $newsBtn = $('#news-start-btn');
+                $newsBtn.text('완료됨');
+                $newsBtn.prop('disabled', true);
+                $newsBtn.removeAttr('onclick');
             }
         },
         error: function(err) {

--- a/src/main/webapp/resources/js/mission/quiz.js
+++ b/src/main/webapp/resources/js/mission/quiz.js
@@ -24,7 +24,7 @@ function getDailyQuiz() {
         type: 'GET',
         dataType: 'json',
         success: function (statusData) {
-            correctAnswers = statusData.solvedCount || 0;
+            correctAnswers = statusData.quizCount || 0;
             $.ajax({
                 url: cpath + '/mission/daily',
                 type: 'GET',

--- a/src/main/webapp/resources/js/mission/quiz.js
+++ b/src/main/webapp/resources/js/mission/quiz.js
@@ -152,7 +152,7 @@ function showCorrectModal(point, explanation) {
     const modalMessage = modal.querySelector('.quiz-modal-message');
 
     // 포인트 메시지 표시
-    pointsMessage.textContent = point + ' 포인트 획득하였습니다.';
+    pointsMessage.textContent = point + ' 포인트를 획득하였습니다.';
     pointsMessage.style.display = 'block';
 
     modalTitle.textContent = '짝짝짝👏👏👏 정답입니다~';

--- a/src/main/webapp/resources/js/news/news.js
+++ b/src/main/webapp/resources/js/news/news.js
@@ -59,20 +59,25 @@ function createNewsCard(article, index) {
     // 날짜 포맷팅
     const formattedDate = formatDate(article.pubDate);
     const safeLink = article.link.replace(/'/g, "\\'");
-
+    const readIndex = readUrls.indexOf(article.link);
     const isRead = readUrls.includes(article.link);
 
-    // 읽었으면 'read-badge' 클래스와 텍스트 표시
-    const readBadgeHtml = isRead
-        ? `<span class="news-read-badge">읽음</span>`
-        : ``;
+    const isPointEarned = isRead && readIndex < 5;
+    let badgesHtml = '';
 
+    if (isRead) {
+        badgesHtml += `<span class="news-read-badge">읽음</span>`;
+        // 포인트 획득 대상이면 뱃지 영구 표시
+        if (isPointEarned) {
+            badgesHtml += `<span class="news-points-badge">+100P</span>`;
+        }
+    }
     return `
         <div class="news-card" onclick="handleNewsClick('${safeLink}', this)">
             <div class="news-card-header">
                 <span class="news-source">네이버 뉴스</span>
                 <span class="news-card-date">${formattedDate}</span>
-                ${readBadgeHtml}
+                ${badgesHtml}
             </div>
             <h2 class="news-card-title">${cleanTitle}</h2>
             <p class="news-card-description">${cleanDescription}</p>
@@ -85,6 +90,7 @@ function handleNewsClick(url, cardElement) {
     // 새 창으로 뉴스 띄우기
     window.open(url, '_blank');
     const $card = $(cardElement);
+    const $header = $card.find('.news-card-header');
 
     // 화면에서 즉시 읽음 처리
     if (!$card.hasClass('read')) {
@@ -106,6 +112,12 @@ function handleNewsClick(url, cardElement) {
         contentType: 'application/json',
         data: JSON.stringify({ newsUrl: url }),
         success: function(data) {
+            if (data.earnedPoint && data.earnedPoint > 0) {
+                // 이미 포인트 뱃지가 있는지 확인 (중복 추가 방지)
+                if ($header.find('.news-points-badge').length === 0) {
+                    $header.append(`<span class="news-points-badge">+${data.earnedPoint}P</span>`);
+                }
+            }
             // 달성률 업데이트
             updateProgressBar(data.progress);
         },


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #224 

---

### 📝 작업 내용
- 메인 페이지의 오늘의 미션 완료 조건을 기존 퀴즈(2회) 단독에서 뉴스 읽기(5회) 포함으로 변경했습니다.
- isTodayMissionCompleted : getTodayMissionStatus의 totalProgress를 참조하여 100% 달성 여부로 판별하도록 수정했습니다.

---

### 📷 스크린샷 (선택)
<img width="1257" height="711" alt="image" src="https://github.com/user-attachments/assets/4b579d2d-e958-4170-9028-f331c365237e" />
퀴즈(2문제) + 뉴스(5번 조회)해야 미션 완료로 변경됩니다.

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
