### PR TITLE
Feat: 한국투자증권 API 호출량 초당 20건 제한 초과 방지 로직 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,12 @@
 		<jjwt.version>0.11.5</jjwt.version>
 	</properties>
 	<dependencies>
+		<!-- 외부 api(한국투자증권 api) 호출 유량 제한 -->
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j-core</artifactId>
+			<version>8.7.0</version>
+		</dependency>
 		<!-- Redisson (Spring Legacy용) -->
 		<dependency>
 			<groupId>org.redisson</groupId>

--- a/src/main/java/com/antmillion/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/antmillion/config/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.antmillion.config;
+
+import com.antmillion.kis.exception.RateLimitExceededException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // Rate Limit 초과 예외 처리 - 429 Too Many Request 반환, Retry-After 헤더 포함
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<Map<String, Object>> handleRateLimitExceeded(RateLimitExceededException ex) {
+        log.warn("Rate limit exceeded: {}", ex.getMessage());
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", "Rate limit exceeded");
+        body.put("message", "한국투자증권 API 호출 한도 초과. 잠시 후 다시 시도해주세요.");
+        body.put("retryAfter", ex.getRetryAfterSeconds());
+
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+                .header("Retry-After", String.valueOf(ex.getRetryAfterSeconds()))
+                .body(body);
+    }
+}

--- a/src/main/java/com/antmillion/config/RedisConfig.java
+++ b/src/main/java/com/antmillion/config/RedisConfig.java
@@ -59,7 +59,10 @@ public class RedisConfig {
         redisTemplate.setConnectionFactory(redisConnectionFactory());
 
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.deactivateDefaultTyping();
+        objectMapper.activateDefaultTyping(  // 이 부분으로 변경
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 
         // 4. 직렬화 설정 (JSON 자동 변환)

--- a/src/main/java/com/antmillion/kis/exception/RateLimitExceededException.java
+++ b/src/main/java/com/antmillion/kis/exception/RateLimitExceededException.java
@@ -1,0 +1,15 @@
+package com.antmillion.kis.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RateLimitExceededException extends RuntimeException {
+    private final long nanosToWait;
+    private final long retryAfterSeconds;
+
+    public RateLimitExceededException(long nanosToWait) {
+        super("KIS API rate limit exceeded. Please retry after " + (nanosToWait / 1_000_000_000) + " seconds");
+        this.nanosToWait = nanosToWait;
+        this.retryAfterSeconds = Math.max(1, nanosToWait / 1_000_000_000);
+    }
+}

--- a/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
+++ b/src/main/java/com/antmillion/kis/handler/KisWebSocketHandler.java
@@ -51,11 +51,11 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         // 1. PINGPONG 처리
         if (payload.contains("PINGPONG")) {
         	manager.updateLastHeartbeatTime(); // 수신 시간 갱신
-            System.out.println("PINGPONG 수신 완료");
+            //System.out.println("PINGPONG 수신 완료");
             try {
             	// 한투 가이드: 받은 PINGPONG 메시지를 그대로 다시 보내야 연결이 유지됨
 				session.sendMessage(new TextMessage(payload));
-				System.out.println("PINGPONG 응답 완료");
+				//System.out.println("PINGPONG 응답 완료");
 			} catch (IOException e) {
 				System.err.println("PINGPONG 응답 전송 실패: " + e.getMessage());
 				manager.monitorHealth(); // 재연결
@@ -65,7 +65,7 @@ public class KisWebSocketHandler extends TextWebSocketHandler {
         
         // 2. JSON 응답 처리 (최초 구독 성공 알림 등)
         if (payload.startsWith("{")) {
-            System.out.println("시스템 메시지(JSON): " + payload);
+            //System.out.println("시스템 메시지(JSON): " + payload);
             return; 
         }
         

--- a/src/main/java/com/antmillion/kis/service/KisApiService.java
+++ b/src/main/java/com/antmillion/kis/service/KisApiService.java
@@ -42,7 +42,10 @@ public class KisApiService {
     private final KisMarketIndexChartRedisRepository kisMarketIndexChartRepository;
     private final KisStockVolumeRankRedisRepository kisStockVolumeRankRedisRepository;
 
+    // Redisson 분산 락
     private final RedissonClient redissonClient;
+    // Bucket4j으로 한국투자증권 api 유량 제어
+    private final RateLimitedKisApiClient rateLimitedClient;
 
     /**
      * KIS 액세스 토큰 조회/발급
@@ -180,21 +183,28 @@ public class KisApiService {
      * @return 한국투자증권 API 반환값
      */
     private KisChartStockPriceResponse periodStockPricesAPI(ChartStockPriceRequest request) {
-        //1.접근 토큰 얻기
-        String token = getKisAccessToken();
-        //2.헤더 설정
-        HttpHeaders headers = createApiHeader(token, "FHKST03010100");
-        //3.URL 생성
-        String url = buildPeriodApiUrl(request);
-        //4.API 호출
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<KisChartStockPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisChartStockPriceResponse.class);
-        //5.응답 처리
-        KisChartStockPriceResponse responseBody = response.getBody();
-        if (responseBody != null && responseBody.getOutput2() != null) {
-            return responseBody;
-        }
-        throw new RuntimeException("기간별 차트 데이터 조회 실패");
+        // Rate Limit + 캐싱 적용
+        return rateLimitedClient.callWithCache(
+                null,
+                () -> {
+                    //1.접근 토큰 얻기
+                    String token = getKisAccessToken();
+                    //2.헤더 설정
+                    HttpHeaders headers = createApiHeader(token, "FHKST03010100");
+                    //3.URL 생성
+                    String url = buildPeriodApiUrl(request);
+                    //4.API 호출
+                    HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+                    ResponseEntity<KisChartStockPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisChartStockPriceResponse.class);
+                    //5.응답 처리
+                    KisChartStockPriceResponse responseBody = response.getBody();
+                    if (responseBody != null && responseBody.getOutput2() != null) {
+                        return responseBody;
+                    }
+                    throw new RuntimeException("기간별 차트 데이터 조회 실패");
+                },
+                60 // TTL 60초
+        );
     }
 
     /**
@@ -257,16 +267,22 @@ public class KisApiService {
      * @return 한국투자증권 api 반환값
      */
     private KisMarketIndexPriceResponse marketIndexPricesAPI(MarketIndexPriceRequest request) {
-        String token = getKisAccessToken();
-        HttpHeaders headers = createApiHeader(token, "FHPUP02120000");
-        String url = buildMarketIndexApiUrl(request);
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<KisMarketIndexPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisMarketIndexPriceResponse.class);
-        KisMarketIndexPriceResponse responseBody = response.getBody();
-        if (responseBody != null && responseBody.getOutput2() != null) {
-            return responseBody;
-        }
-        throw new RuntimeException("국내 시장 지수 차트 데이터 조회 실패");
+        return rateLimitedClient.callWithCache(
+                null,
+                () -> {
+                    String token = getKisAccessToken();
+                    HttpHeaders headers = createApiHeader(token, "FHPUP02120000");
+                    String url = buildMarketIndexApiUrl(request);
+                    HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+                    ResponseEntity<KisMarketIndexPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisMarketIndexPriceResponse.class);
+                    KisMarketIndexPriceResponse responseBody = response.getBody();
+                    if (responseBody != null && responseBody.getOutput2() != null) {
+                        return responseBody;
+                    }
+                    throw new RuntimeException("국내 시장 지수 차트 데이터 조회 실패");
+                },
+                60
+        );
     }
 
     /**
@@ -351,16 +367,22 @@ public class KisApiService {
     }
 
     private KisStockVolumeRankResponse stockVolumeRankAPI(StockVolumeRankRequest request) {
-        String token = getKisAccessToken();
-        HttpHeaders headers = createApiHeader(token, "FHPST01710000");
-        String url = buildStockVolumeRankUrl(request);
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<KisStockVolumeRankResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisStockVolumeRankResponse.class);
-        KisStockVolumeRankResponse responseBody = response.getBody();
-        if (responseBody != null) {
-            return responseBody;
-        }
-        throw new RuntimeException("거래량 순위 데이터 조회 실패");
+        return rateLimitedClient.callWithCache(
+                null,
+                () -> {
+                    String token = getKisAccessToken();
+                    HttpHeaders headers = createApiHeader(token, "FHPST01710000");
+                    String url = buildStockVolumeRankUrl(request);
+                    HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+                    ResponseEntity<KisStockVolumeRankResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisStockVolumeRankResponse.class);
+                    KisStockVolumeRankResponse responseBody = response.getBody();
+                    if (responseBody != null) {
+                        return responseBody;
+                    }
+                    throw new RuntimeException("거래량 순위 데이터 조회 실패");
+                },
+                60
+        );
     }
 
     private String buildStockVolumeRankUrl(StockVolumeRankRequest request) {
@@ -420,17 +442,23 @@ public class KisApiService {
      * 
      */
     private StreamMinutePriceResponse streamMinutePricesAPI(StreamMinutePriceRequest request) {
-    	String token = getKisAccessToken();
-        HttpHeaders headers = createApiHeader(token, "FHKST03010230");
-        headers.set("tr_cont", "N"); // 연속 거래 여부
-        String url = buildStreamMinuteApiUrl(request);
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<StreamMinutePriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, StreamMinutePriceResponse.class);
-        StreamMinutePriceResponse responseBody = response.getBody();
-        if(responseBody != null) {
-        	return responseBody;
-        }
-        throw new RuntimeException("국내 시장 일별 분봉 데이터 조회 실패");
+        return rateLimitedClient.callWithCache(
+                null,
+                () -> {
+                    String token = getKisAccessToken();
+                    HttpHeaders headers = createApiHeader(token, "FHKST03010230");
+                    headers.set("tr_cont", "N"); // 연속 거래 여부
+                    String url = buildStreamMinuteApiUrl(request);
+                    HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+                    ResponseEntity<StreamMinutePriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, StreamMinutePriceResponse.class);
+                    StreamMinutePriceResponse responseBody = response.getBody();
+                    if(responseBody != null) {
+                        return responseBody;
+                    }
+                    throw new RuntimeException("국내 시장 일별 분봉 데이터 조회 실패");
+                },
+                60
+        );
     }
     
     /**
@@ -453,37 +481,54 @@ public class KisApiService {
     }
 
     public Integer getCurrentPrice(CurrentPriceRequest request) {
-        String token = getKisAccessToken();
-        HttpHeaders headers = createApiHeader(token, "FHKST01010100");
-        URI uri = URI.create(config.getBaseUrl() + KisApiConstant.PRESENT_PRICE);
-        String url = UriComponentsBuilder.fromUri(uri)
-                .queryParam("FID_COND_MRKT_DIV_CODE", request.getMarketCode())
-                .queryParam("FID_INPUT_ISCD", request.getStockCode())
-                .build().toUriString();
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<KisCurrentPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisCurrentPriceResponse.class);
-        KisCurrentPriceResponse responseBody = response.getBody();
-        if(responseBody != null && responseBody.getOutput() != null) {
-            return Integer.parseInt(responseBody.getOutput().getCurrentPrice());
-        }
-        throw new RuntimeException("현재가 조회 실패");
+        // 현재가는 실시간성이 중요하므로 캐싱 TTL 짧게
+        String cacheKey = "current:price:" + request.getStockCode();
+
+        return rateLimitedClient.callWithCache(
+                cacheKey,
+                () -> {
+                    String token = getKisAccessToken();
+                    HttpHeaders headers = createApiHeader(token, "FHKST01010100");
+                    URI uri = URI.create(config.getBaseUrl() + KisApiConstant.PRESENT_PRICE);
+                    String url = UriComponentsBuilder.fromUri(uri)
+                            .queryParam("FID_COND_MRKT_DIV_CODE", request.getMarketCode())
+                            .queryParam("FID_INPUT_ISCD", request.getStockCode())
+                            .build().toUriString();
+                    HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+                    ResponseEntity<KisCurrentPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisCurrentPriceResponse.class);
+                    KisCurrentPriceResponse responseBody = response.getBody();
+                    if(responseBody != null && responseBody.getOutput() != null) {
+                        return Integer.parseInt(responseBody.getOutput().getCurrentPrice());
+                    }
+                    throw new RuntimeException("현재가 조회 실패");
+                },
+                10
+        );
     }
 
     public CurrentPrice getCurrentPriceDetail(CurrentPriceRequest request) {
-        String token = getKisAccessToken();
-        HttpHeaders headers = createApiHeader(token, "FHKST01010100");
-        URI uri = URI.create(config.getBaseUrl() + KisApiConstant.PRESENT_PRICE);
-        String url = UriComponentsBuilder.fromUri(uri)
-                .queryParam("FID_COND_MRKT_DIV_CODE", request.getMarketCode())
-                .queryParam("FID_INPUT_ISCD", request.getStockCode())
-                .build().toUriString();
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<KisCurrentPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisCurrentPriceResponse.class);
-        KisCurrentPriceResponse responseBody = response.getBody();
-        if(responseBody != null && responseBody.getOutput() != null) {
-            return responseBody.getOutput();
-        }
-        throw new RuntimeException("현재가 정보 조회 실패");
+        String cacheKey = "current:price:detail:" + request.getStockCode();
+
+        return rateLimitedClient.callWithCache(
+                cacheKey,
+                () -> {
+                    String token = getKisAccessToken();
+                    HttpHeaders headers = createApiHeader(token, "FHKST01010100");
+                    URI uri = URI.create(config.getBaseUrl() + KisApiConstant.PRESENT_PRICE);
+                    String url = UriComponentsBuilder.fromUri(uri)
+                            .queryParam("FID_COND_MRKT_DIV_CODE", request.getMarketCode())
+                            .queryParam("FID_INPUT_ISCD", request.getStockCode())
+                            .build().toUriString();
+                    HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
+                    ResponseEntity<KisCurrentPriceResponse> response = restTemplate.exchange(url, HttpMethod.GET, httpEntity, KisCurrentPriceResponse.class);
+                    KisCurrentPriceResponse responseBody = response.getBody();
+                    if(responseBody != null && responseBody.getOutput() != null) {
+                        return responseBody.getOutput();
+                    }
+                    throw new RuntimeException("현재가 정보 조회 실패");
+                },
+                10
+        );
     }
 
     public List<CurrentPrice> getCurrentPricesDetail(List<String> stockCodes) {

--- a/src/main/java/com/antmillion/kis/service/RateLimitedKisApiClient.java
+++ b/src/main/java/com/antmillion/kis/service/RateLimitedKisApiClient.java
@@ -64,9 +64,39 @@ public class RateLimitedKisApiClient {
                 }
             }
 
-            // 캐시도 없음 → 429 예외 발생
+            // 캐시도 없음 → 재시도 로직
             long nanosToWait = probe.getNanosToWaitForRefill();
-            log.error("Rate limit exceeded and no cache available. Wait: {}ms", nanosToWait / 1_000_000);
+            long millisToWait = nanosToWait / 1_000_000;
+
+            // 대기 시간이 1초 이하면 재시도
+            if (millisToWait <= 1000) {
+                log.info("Rate limit exceeded but retrying after {}ms", millisToWait);
+
+                try {
+                    // 토큰 리필 대기
+                    Thread.sleep(millisToWait + 50); // 여유있게 50ms 추가
+
+                    // 재시도
+                    ConsumptionProbe retryProbe = bucket.tryConsumeAndReturnRemaining(1);
+                    if (retryProbe.isConsumed()) {
+                        log.info("Retry successful. Remaining tokens: {}", retryProbe.getRemainingTokens());
+                        T result = apiCall.get();
+
+                        // Redis 캐싱
+                        if (cacheKey != null && result != null) {
+                            redisTemplate.opsForValue().set(cacheKey, result, ttl, TimeUnit.SECONDS);
+                        }
+
+                        return result;
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.error("Retry interrupted", e);
+                }
+            }
+
+            // 재시도 실패 또는 대기 시간 너무 김 → 429 예외 발생
+            log.error("Rate limit exceeded and no cache available. Wait: {}ms", millisToWait);
             throw new RateLimitExceededException(nanosToWait);
         }
     }
@@ -86,7 +116,7 @@ public class RateLimitedKisApiClient {
         }
     }
 
-    // 남은 토큰 수 조회
+    // 남은 토큰 수 조회 - 모니터링용
     public long getAvailableTokens() {
         return bucket.getAvailableTokens();
     }

--- a/src/main/java/com/antmillion/kis/service/RateLimitedKisApiClient.java
+++ b/src/main/java/com/antmillion/kis/service/RateLimitedKisApiClient.java
@@ -1,0 +1,31 @@
+package com.antmillion.kis.service;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RateLimitedKisApiClient {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final Bucket bucket;
+
+    // 20 tokens, 1초마다 refill
+    public RateLimitedKisApiClient(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+
+        // 1초당 20건 제한 설정
+        Bandwidth limit = Bandwidth.simple(20, Duration.ofSeconds(1));
+        this.bucket = Bucket.builder()
+                .addLimit(limit)
+                .build();
+
+        log.info("RateLimitedKisApiClient 초기화: 1초당 20건 제한");
+    }
+}

--- a/src/main/java/com/antmillion/kis/service/RateLimitedKisApiClient.java
+++ b/src/main/java/com/antmillion/kis/service/RateLimitedKisApiClient.java
@@ -1,17 +1,20 @@
 package com.antmillion.kis.service;
 
+import com.antmillion.kis.exception.RateLimitExceededException;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class RateLimitedKisApiClient {
     private final RedisTemplate<String, Object> redisTemplate;
     private final Bucket bucket;
@@ -28,4 +31,64 @@ public class RateLimitedKisApiClient {
 
         log.info("RateLimitedKisApiClient 초기화: 1초당 20건 제한");
     }
+
+
+    // Rate Limit이 적용된 API 호출 (Redis 캐싱 O)
+    public <T> T callWithCache(String cacheKey, Supplier<T> apiCall, long ttl) {
+        // 토큰 소비 시도
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+
+        if (probe.isConsumed()) {
+            // 토큰 있음 → API 호출
+            log.debug("Rate limit OK. Remaining tokens: {}", probe.getRemainingTokens());
+            T result = apiCall.get();
+
+            // Redis 캐싱 (cacheKey가 null이 아닌 경우만)
+            if (cacheKey != null && result != null) {
+                redisTemplate.opsForValue().set(cacheKey, result, ttl, TimeUnit.SECONDS);
+                log.debug("Redis에 캐싱: key={}, ttl={}초", cacheKey, ttl);
+            }
+
+            return result;
+        } else {
+            // 토큰 없음 → Redis 캐시 조회
+            log.warn("Rate limit exceeded. Trying Redis cache: key={}", cacheKey);
+
+            if (cacheKey != null) {
+                @SuppressWarnings("unchecked")
+                T cached = (T) redisTemplate.opsForValue().get(cacheKey);
+
+                if (cached != null) {
+                    log.info("Redis 캐시 반환: key={}", cacheKey);
+                    return cached;
+                }
+            }
+
+            // 캐시도 없음 → 429 예외 발생
+            long nanosToWait = probe.getNanosToWaitForRefill();
+            log.error("Rate limit exceeded and no cache available. Wait: {}ms", nanosToWait / 1_000_000);
+            throw new RateLimitExceededException(nanosToWait);
+        }
+    }
+
+    // Rate Limit이 적용된 API 호출 (Redis 캐싱 X)
+    public <T> T callWithoutCache(Supplier<T> apiCall) {
+        ConsumptionProbe probe = bucket.tryConsumeAndReturnRemaining(1);
+
+        if (probe.isConsumed()) {
+            log.debug("Rate limit OK (no cache). Remaining tokens: {}", probe.getRemainingTokens());
+            return apiCall.get();
+        } else {
+            // 캐시 없이 바로 429 예외
+            long nanosToWait = probe.getNanosToWaitForRefill();
+            log.error("Rate limit exceeded (no cache). Wait: {}ms", nanosToWait / 1_000_000);
+            throw new RateLimitExceededException(nanosToWait);
+        }
+    }
+
+    // 남은 토큰 수 조회
+    public long getAvailableTokens() {
+        return bucket.getAvailableTokens();
+    }
+
 }

--- a/src/main/java/com/antmillion/stock/component/StockCache.java
+++ b/src/main/java/com/antmillion/stock/component/StockCache.java
@@ -52,4 +52,14 @@ public class StockCache {
                 .findFirst()
                 .orElse(null);
     }
+
+    // 캐시 갱신 메서드 추가
+    public void refresh() {
+        cache.clear();
+        stockMapper.findAll().forEach(s -> {
+            cache.put(
+                    s.getStockCode(),
+                    new StockDTO(s.getStockCode(), s.getStockName(), null));
+        });
+    }
 }

--- a/src/main/java/com/antmillion/stock/controller/StockSyncController.java
+++ b/src/main/java/com/antmillion/stock/controller/StockSyncController.java
@@ -44,6 +44,8 @@ public class StockSyncController {
             response.put("insertedCount", result.getInsertedCount());
             response.put("deletedCount", result.getDeletedCount());
             response.put("totalDownloaded", result.getTotalDownloaded());
+            response.put("executionTimeMs", result.getExecutionTimeMs());
+            response.put("executionTimeSec", result.getExecutionTimeMs() / 1000.0);
 
             log.info("종목 동기화 완료: {}", result);
 

--- a/src/main/java/com/antmillion/stock/dto/SyncResult.java
+++ b/src/main/java/com/antmillion/stock/dto/SyncResult.java
@@ -11,4 +11,5 @@ public class SyncResult {
     private int insertedCount;
     private int deletedCount;
     private int totalDownloaded;
+    private long executionTimeMs; // 소요 시간 (밀리초)
 }

--- a/src/main/java/com/antmillion/stock/mapper/StockSyncMapper.java
+++ b/src/main/java/com/antmillion/stock/mapper/StockSyncMapper.java
@@ -1,11 +1,13 @@
 package com.antmillion.stock.mapper;
 
 import com.antmillion.stock.dto.StockDTO;
-import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StockSyncMapper {
     void truncateTemp();
     void insertTempStock(StockDTO stock);
+    void insertTempStockBatch(List<StockDTO> stocks); // 배치 삽입 추가
     int insertNewStocks();
     int deleteOldStocks();
     int countStock();

--- a/src/main/java/com/antmillion/stock/service/KisStockSyncService.java
+++ b/src/main/java/com/antmillion/stock/service/KisStockSyncService.java
@@ -1,5 +1,6 @@
 package com.antmillion.stock.service;
 
+import com.antmillion.stock.component.StockCache;
 import com.antmillion.stock.dto.StockDTO;
 import com.antmillion.stock.dto.SyncResult;
 import com.antmillion.stock.mapper.StockSyncMapper;
@@ -26,6 +27,7 @@ public class KisStockSyncService {
     private static final String KOSDAQ_URL = "https://new.real.download.dws.co.kr/common/master/kosdaq_code.mst.zip";
 
     private final StockSyncMapper stockSyncMapper;
+    private final StockCache stockCache;
 
     @Transactional
     public SyncResult syncAllStocks() throws Exception {
@@ -54,16 +56,20 @@ public class KisStockSyncService {
         log.info("temp_stock에 종목 삽입 중... (코스피: {}, 코스닥: {})",
                 kospiStocks.size(), kosdaqStocks.size());
 
-        int totalInserted = 0;
-        for (StockDTO stock : kospiStocks) {
-            stockSyncMapper.insertTempStock(stock);
-            totalInserted++;
+        // 배치 삽입으로 성능 개선
+        List<StockDTO> allStocks = new ArrayList<>();
+        allStocks.addAll(kospiStocks);
+        allStocks.addAll(kosdaqStocks);
+        
+        // 500개씩 나눠서 배치 삽입 (한 번에 너무 많으면 쿼리가 길어질 수 있음)
+        int batchSize = 500;
+        for (int i = 0; i < allStocks.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, allStocks.size());
+            List<StockDTO> batch = allStocks.subList(i, end);
+            stockSyncMapper.insertTempStockBatch(batch);
         }
-        for (StockDTO stock : kosdaqStocks) {
-            stockSyncMapper.insertTempStock(stock);
-            totalInserted++;
-        }
-
+        
+        int totalInserted = allStocks.size();
         log.info("temp_stock에 {} 종목 삽입 완료", totalInserted);
 
         // 5. stock 테이블과 동기화
@@ -84,6 +90,11 @@ public class KisStockSyncService {
         // 동기화 후 종목 수 확인
         int afterCount = stockSyncMapper.countStock();
         log.info("동기화 후 stock 테이블 종목 수: {}", afterCount);
+
+        // 6. 캐시 갱신
+        log.info("StockCache 갱신 중...");
+        stockCache.refresh();
+        log.info("StockCache 갱신 완료");
 
         // 결과 반환
         SyncResult result = SyncResult.builder()

--- a/src/main/java/com/antmillion/stock/service/KisStockSyncService.java
+++ b/src/main/java/com/antmillion/stock/service/KisStockSyncService.java
@@ -38,6 +38,7 @@ public class KisStockSyncService {
     // 코스피+코스닥 종목 정보를 다운로드하여 DB와 동기화
     @Transactional
     public SyncResult syncAllStocks(String baseDir) throws Exception {
+        long startTime = System.currentTimeMillis();
         log.info("=== 종목 동기화 시작 ===");
 
         // 1. temp_stock 테이블 초기화
@@ -56,11 +57,13 @@ public class KisStockSyncService {
         log.info("temp_stock에 종목 삽입 중... (코스피: {}, 코스닥: {})",
                 kospiStocks.size(), kosdaqStocks.size());
 
+        long insertStartTime = System.currentTimeMillis();
+
         // 배치 삽입으로 성능 개선
         List<StockDTO> allStocks = new ArrayList<>();
         allStocks.addAll(kospiStocks);
         allStocks.addAll(kosdaqStocks);
-        
+
         // 500개씩 나눠서 배치 삽입 (한 번에 너무 많으면 쿼리가 길어질 수 있음)
         int batchSize = 500;
         for (int i = 0; i < allStocks.size(); i += batchSize) {
@@ -68,9 +71,30 @@ public class KisStockSyncService {
             List<StockDTO> batch = allStocks.subList(i, end);
             stockSyncMapper.insertTempStockBatch(batch);
         }
-        
+
         int totalInserted = allStocks.size();
-        log.info("temp_stock에 {} 종목 삽입 완료", totalInserted);
+        long insertEndTime = System.currentTimeMillis();
+        log.info("temp_stock에 {} 종목 삽입 완료 (소요 시간: {}ms)",
+                totalInserted, (insertEndTime - insertStartTime));
+
+//        log.info("temp_stock에 종목 삽입 중... (코스피: {}, 코스닥: {})",
+//                kospiStocks.size(), kosdaqStocks.size());
+//
+//        long insertStartTime = System.currentTimeMillis();
+//
+//        int totalInserted = 0;
+//        for (StockDTO stock : kospiStocks) {
+//            stockSyncMapper.insertTempStock(stock);
+//            totalInserted++;
+//        }
+//        for (StockDTO stock : kosdaqStocks) {
+//            stockSyncMapper.insertTempStock(stock);
+//            totalInserted++;
+//        }
+//
+//        long insertEndTime = System.currentTimeMillis();
+//        log.info("temp_stock에 {} 종목 삽입 완료 (소요 시간: {}ms)",
+//                totalInserted, (insertEndTime - insertStartTime));
 
         // 5. stock 테이블과 동기화
         log.info("stock 테이블 동기화 중...");
@@ -93,8 +117,14 @@ public class KisStockSyncService {
 
         // 6. 캐시 갱신
         log.info("StockCache 갱신 중...");
+        long cacheStartTime = System.currentTimeMillis();
         stockCache.refresh();
-        log.info("StockCache 갱신 완료");
+        long cacheEndTime = System.currentTimeMillis();
+        log.info("StockCache 갱신 완료 (소요 시간: {}ms)", (cacheEndTime - cacheStartTime));
+
+        // 총 소요 시간 계산
+        long endTime = System.currentTimeMillis();
+        long totalTime = endTime - startTime;
 
         // 결과 반환
         SyncResult result = SyncResult.builder()
@@ -103,10 +133,12 @@ public class KisStockSyncService {
                 .insertedCount(insertedCount)
                 .deletedCount(deletedCount)
                 .totalDownloaded(totalInserted)
+                .executionTimeMs(totalTime)
                 .build();
-
+        
         log.info("=== 종목 동기화 완료 ===");
         log.info("결과: {}", result);
+        log.info("총 소요 시간: {}ms ({}초)", totalTime, totalTime / 1000.0);
 
         return result;
     }

--- a/src/main/resources/mappers/stock/StockSyncMapper.xml
+++ b/src/main/resources/mappers/stock/StockSyncMapper.xml
@@ -14,6 +14,15 @@
         ON DUPLICATE KEY UPDATE stock_name = VALUES(stock_name)
     </insert>
 
+    <insert id="insertTempStockBatch">
+        INSERT IGNORE INTO temp_stock(stock_code, stock_name)
+        VALUES
+        <foreach collection="list" item="stock" separator=",">
+            (#{stock.stockCode}, #{stock.stockName})
+        </foreach>
+        ON DUPLICATE KEY UPDATE stock_name = VALUES(stock_name)
+    </insert>
+
     <insert id="insertNewStocks">
         INSERT INTO stock(stock_code, stock_name)
         SELECT t.stock_code, t.stock_name


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #227 

---

### 📝 작업 내용

한국투자증권 API 유량 제한 초과 시 서비스 이용 제한 또는 데이터 조회 실패 발생 가능성이 있습니다.

- 한국투자증권 API 호출 유량 제한(1초당 20건)을 준수하기 위해 Bucket4j를 활용한 Rate Limiter를 구현했습니다.
- Redis 기반 Bucket4j 토큰 버킷으로 전역 유량 제한을 걸어 초당 20건 제한을 보장합니다.

- 흐름 설명
```mermaid
flowchart TD

A[요청] --> B[KisApiService]
B --> C[RateLimitedKisApiClient]
C --> D[Bucket4j 토큰 체크]

D -->|"토큰 있음 (20건 이내)"| E[API 호출 실행]
E --> F[Redis 캐싱]
F --> G[결과 반환]

D -->|"토큰 없음 (초과)"| H[Redis 캐시 조회]
H -->|"캐시 있음"| G
H -->|"캐시 없음"| I[대기 후 재시도]
I -->|"재시도 실패 or 대기 시간 김"| J[429 에러]
```
Redis 캐싱으로 인해 429 에러까지 갈 일이 거의 없습니다. (추후에 429 에러 시 다시 재시도 추가 가능)

## 🚀 성능 개선
- 종목 동기화 성능을 개선하였습니다.
- temp_stock에 한국투자증권에서 다운로드 받은 종목을 삽입 시에 배치 삽입을 적용하였습니다.
- 개선 결과는 아래 스크린샷을 참고해주세요.


---

### 📷 스크린샷 (선택)
관심종목 연속 클릭 시 로그
20건을 넘어가는 요청 로그 : "Rate limit exceeded. Trying Redis cache: key=current:price:detail:086520"
캐싱된 데이터 얻어서 사용하는 로그 : "Redis 캐시 반환: key=current:price:detail:086520"
<img width="820" height="401" alt="스크린샷 2026-01-29 205839" src="https://github.com/user-attachments/assets/59f93113-c473-446f-a9e1-e7a9e4ac6322" />

종목 동기화 성능 개선 전 : 약 16초
<img width="428" height="261" alt="스크린샷 2026-01-30 110050" src="https://github.com/user-attachments/assets/a0456508-c4ce-4a0b-884a-54294c30ad03" />

종목 동기화 성능 개선 후 : 약 0.8초
<img width="425" height="304" alt="스크린샷 2026-01-30 110529" src="https://github.com/user-attachments/assets/da1b147e-9845-47dd-9351-bfa7b32cc8bc" />


---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [x] PR 제목 규칙을 지켰다
- [x] 추가/수정 사항을 설명했다
- [x] 이슈 번호를 연결했다
