### PR TITLE
Refactor: 로그인, 회원가입 비밀번호 특수문자 허용

### DIFF
--- a/src/main/java/com/antmillion/myinfo/controller/MyInfoController.java
+++ b/src/main/java/com/antmillion/myinfo/controller/MyInfoController.java
@@ -27,7 +27,7 @@ import com.antmillion.myinfo.service.MyInfoService;
 @Controller
 public class MyInfoController {
 
-    private static final Pattern PW_RULE = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$");
+	private static final Pattern PW_RULE = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)\\S{8,}$");
     private static final DateTimeFormatter JOIN_FMT = DateTimeFormatter.ofPattern("yyyy. M. d 가입");
 
     private final MyInfoService myInfoService;
@@ -80,7 +80,7 @@ public class MyInfoController {
         }
         if (!PW_RULE.matcher(newPassword).matches()) {
             return ResponseEntity.badRequest()
-                    .body(Map.of("ok", false, "message", "비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다."));
+                    .body(Map.of("ok", false, "message", "비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다."));
         }
 
         try {

--- a/src/main/java/com/antmillion/user/controller/SignController.java
+++ b/src/main/java/com/antmillion/user/controller/SignController.java
@@ -34,7 +34,7 @@ import com.antmillion.mail.service.EmailVerificationService;
 public class SignController {
 
 	private static final Pattern EMAIL_RULE = Pattern.compile("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$");
-	private static final Pattern PW_RULE = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}$");
+	private static final Pattern PW_RULE = Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)\\S{8,}$");
 
 	private final TermsProvider termsProvider;
 	private final SignService signService;
@@ -66,10 +66,13 @@ public class SignController {
 			ra.addFlashAttribute("email", email);
 			return "redirect:/login";
 		}
+		if (password == null || password.isBlank()) {
+		    ra.addFlashAttribute("error", "비밀번호를 입력해 주세요.");
+		    return "login/login";
+		}
 		if (password == null || !PW_RULE.matcher(password).matches()) {
-			ra.addFlashAttribute("loginError", "비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다.");
-			ra.addFlashAttribute("email", email);
-			return "redirect:/login";
+		    ra.addFlashAttribute("error", "비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다.");
+		    return "login/signup";
 		}
 		try {
 			TokenPair tokens = signService.login(email, password);
@@ -312,7 +315,7 @@ public class SignController {
 			throw new IllegalStateException("비밀번호를 입력해 주세요.");
 		}
 		if (!PW_RULE.matcher(password).matches()) {
-			throw new IllegalStateException("비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다.");
+			throw new IllegalStateException("비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다.");
 		}
 		if (!password.equals(passwordConfirm)) {
 			throw new IllegalStateException("비밀번호가 일치하지 않습니다.");

--- a/src/main/webapp/WEB-INF/views/login/login.jsp
+++ b/src/main/webapp/WEB-INF/views/login/login.jsp
@@ -22,7 +22,7 @@
 
 				<form class="form" method="post" action="${cpath}/login">
 					<input type="email" name="email" placeholder="이메일을 입력하세요" value="${email}" required />
-					<input type="password" name="password" placeholder="비밀번호를 입력하세요" title="비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다." pattern="^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$" required/>
+					<input type="password" name="password" placeholder="비밀번호를 입력하세요" title="비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다." pattern="^(?=.*[A-Za-z])(?=.*\d)\S{8,}$" required/>
 					<c:if test="${not empty loginError}">
                         <div class="msg-danger">${loginError}</div>
                     </c:if>

--- a/src/main/webapp/WEB-INF/views/login/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/login/signup.jsp
@@ -34,8 +34,8 @@
         <div id="emailVerifyMsg"></div>
 
         <input type="hidden" id="emailVerified" value="N" />
-        <input type="password" name="password" placeholder="비밀번호" title="비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다." pattern="^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$" required/>
-        <input type="password" name="passwordConfirm" placeholder="비밀번호 확인" title="비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다." pattern="^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$" required/>
+        <input type="password" name="password" placeholder="비밀번호" title="비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다." pattern="^(?=.*[A-Za-z])(?=.*\d)\S{8,}$" required/>
+        <input type="password" name="passwordConfirm" placeholder="비밀번호 확인" title="비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다." pattern="^(?=.*[A-Za-z])(?=.*\d)\S{8,}$" required/>
 
         <!-- 에러 메시지(있을 때만 표시) -->
         <c:if test="${not empty error}">

--- a/src/main/webapp/resources/js/myinfo/myinfo.js
+++ b/src/main/webapp/resources/js/myinfo/myinfo.js
@@ -9,7 +9,7 @@
   // JSP에서 주입: const isKakao = true/false;
   const IS_KAKAO = (typeof isKakao === 'boolean') ? isKakao : false;
 
-  const PW_RULE = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+  const PW_RULE = /^(?=.*[A-Za-z])(?=.*\d)\S{8,}$/;
 
   function $(id) {
     return document.getElementById(id);
@@ -125,7 +125,7 @@
           return;
         }
         if (!PW_RULE.test(next)) {
-          alert('비밀번호는 영문과 숫자를 포함해 8자리 이상이어야 합니다.');
+          alert('비밀번호는 8자리 이상, 영문/숫자를 포함하고 공백 없이 특수문자를 사용할 수 있습니다.');
           return;
         }
 


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #237 

---

### 📝 작업 내용
- 로그인, 회원가입 비밀번호 특수문자 허용
- 기존에는 문자와 숫자만 허용했고 둘을 무조건 섞어야했고 특수문자는 허용하지 않았지만 문자와 숫자 혼용 요구는 유지한채로 특수문자 입력을 허용

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
