### PR TITLE
Refactor: 미션 달성률 계산 로직 개편 (가중치 적용)

### DIFF
--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -184,13 +184,10 @@ public class MissionServiceImpl implements MissionService {
         int readNewsCount = newsMapper.countTodayNewsRead(userId);
         int newsGoal = 5;
 
-        // 전체 달성률 계산
-        // 분자: (푼 퀴즈 수 + 읽은 뉴스 수)
-        int currentTotal = solvedQuizCount + readNewsCount;
-        // 분모: (퀴즈 목표 2 + 뉴스 목표 5) = 7
-        int goalTotal = quizGoal + newsGoal;
-
-        int totalProgress = (int) ((double) currentTotal / goalTotal * 100);
+        // 전체 달성률 계산 (가중치 적용)
+        int quizScore = solvedQuizCount * 20;         // 퀴즈 1문제당 20%
+        int newsScore = readNewsCount * 12;           // 뉴스 1문제당 12%
+        int totalProgress = quizScore + newsScore;
         totalProgress = Math.min(totalProgress, 100); // 100% 넘지 않게
 
         // 데이터 담기


### PR DESCRIPTION


## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #241 

---

### 📝 작업 내용
- 기존 단순 횟수 합산(1/7) 방식에서 가중치 부여 방식으로 변경했습니다.
경제 퀴즈(2회) - 회당 20% (총 40%) 
증권 뉴스(5회) - 회당 12% (총 60%)

---

### 📷 스크린샷 (선택)
<img width="1280" height="710" alt="image" src="https://github.com/user-attachments/assets/04401af3-019f-4482-8dcc-fc6b8fe532cf" />
미션 달성률 : 경제 퀴즈 2문제(40%) + 증권 뉴스 1회(12%) = 52%

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
