### PR TITLE
Fix: 네이버 뉴스 API 스케줄러: 초기 지연 및 뉴스 필터링 로직 강화

### DIFF
--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -42,34 +42,79 @@ public class NaverNewsService {
     private void initNews() {
         List<NaverNewsItemDTO> fetched = fetchFromNaverNewsApi(50);
         newsList.clear();
-        newsList.addAll(
-                fetched.stream()
-                        .limit(5)
-                        .collect(Collectors.toList())
-        );
+        List<NaverNewsItemDTO> initial = fetched.stream()
+                .limit(5)
+                .collect(Collectors.toList());
+        newsList.addAll(initial);
+
+        if (initial.isEmpty()) {
+            log.info("초기화될 뉴스가 없습니다.");
+        } else {
+            log.info("처음 뉴스 {}개 조회", initial.size());
+        }
     }
 
     // 1시간마다 최신 2개 추가
     @Scheduled(initialDelay = 60 * 60 * 1000, fixedRate = 60 * 60 * 1000)
     public void appendHourlyNews() {
-        if (newsList.isEmpty()) {
-            initNews();
+        // 네이버 API 호출
+        List<NaverNewsItemDTO> latest = fetchFromNaverNewsApi(100);
+        if (latest.isEmpty()) {
+            log.info("네이버에서 가져온 뉴스가 없습니다.");
             return;
         }
 
-        List<NaverNewsItemDTO> latest = fetchFromNaverNewsApi(100);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
 
-        Set<String> existingLinks = newsList.stream()
-                .map(NaverNewsItemDTO::getLink)
-                .collect(Collectors.toSet());
+        synchronized (newsList) {
+            // 기존 링크 스냅샷 및 현재 저장된 가장 최신 시간 계산
+            Set<String> existingLinks = newsList.stream()
+                    .map(NaverNewsItemDTO::getLink)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
 
-        List<NaverNewsItemDTO> newItems = latest.stream()
-                .filter(item -> !existingLinks.contains(item.getLink()))
-                .limit(2)
-                .collect(Collectors.toList());
+            Optional<ZonedDateTime> currentNewest = newsList.stream()
+                    .map(NaverNewsItemDTO::getPubDate)
+                    .filter(Objects::nonNull)
+                    .map(s -> parsePubDate(s, formatter))
+                    .filter(Objects::nonNull)
+                    .max(Comparator.naturalOrder());
 
-        if (!newItems.isEmpty()) {
-            newsList.addAll(0, newItems);
+            // latest에서 링크 중복 제거 + pubDate가 현재 저장된 최신보다 이후인 것만 선택
+            List<NaverNewsItemDTO> candidates = latest.stream()
+                    .filter(item -> item.getLink() != null && item.getPubDate() != null)
+                    .filter(item -> !existingLinks.contains(item.getLink()))
+                    .filter(item -> {
+                        ZonedDateTime itemDt = parsePubDate(item.getPubDate(), formatter);
+                        if (itemDt == null) return false;
+                        return currentNewest.map(cur -> itemDt.isAfter(cur)).orElse(true);
+                    })
+                    .sorted((a, b) -> {
+                        ZonedDateTime da = parsePubDate(a.getPubDate(), formatter);
+                        ZonedDateTime db = parsePubDate(b.getPubDate(), formatter);
+                        if (da == null || db == null) return 0;
+                        return db.compareTo(da); // 최신순
+                    })
+                    .limit(2)
+                    .collect(Collectors.toList());
+
+            if (!candidates.isEmpty()) {
+                newsList.addAll(0, candidates);
+                log.info("뉴스 {}개가 추가되었습니다. 총 뉴스 {}개", candidates.size(), newsList.size());
+                candidates.forEach(it -> log.debug("추가된 뉴스: title='{}' link='{}' pubDate='{}'", it.getTitle(), it.getLink(), it.getPubDate()));
+            } else {
+                log.info("추가될 뉴스가 없습니다.");
+            }
+        }
+    }
+
+    private ZonedDateTime parsePubDate(String pubDateStr, DateTimeFormatter formatter) {
+        if (pubDateStr == null) return null;
+        try {
+            return ZonedDateTime.parse(pubDateStr, formatter);
+        } catch (Exception e) {
+            log.debug("pubDate 파싱 실패: {}", pubDateStr);
+            return null;
         }
     }
 

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -50,7 +50,7 @@ public class NaverNewsService {
     }
 
     // 1시간마다 최신 2개 추가
-    @Scheduled(fixedRate = 60 * 60 * 1000)
+    @Scheduled(initialDelay = 60 * 60 * 1000, fixedRate = 60 * 60 * 1000)
     public void appendHourlyNews() {
         if (newsList.isEmpty()) {
             initNews();

--- a/src/main/webapp/resources/css/news/news.css
+++ b/src/main/webapp/resources/css/news/news.css
@@ -144,8 +144,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    max-width: 1200px;
-    margin: 0 auto;
+    width: 100%;
 }
 
 .news-card {


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #251 

---

### 📝 작업 내용
- @scheduled에 initialDelay추가하여 첫 실행 지연 설정
- pubDate 비교를 통한 최신 뉴스만 추가하도록 로직 강화
- 로그 추가로 뉴스 추가/초기화 과정 모니터링 가능하도록 개선
- 뉴스 카드 컨테이너 전체 너비로 확장


---

### 📷 스크린샷 (선택)
수정전 최신 뉴스 5개 + 2개 더 로드되는 오류
<img width="1263" height="711" alt="image" src="https://github.com/user-attachments/assets/02ece2e6-23fd-4307-8ba7-bd75c05b8b5b" />
<img width="1263" height="711" alt="image" src="https://github.com/user-attachments/assets/0b0fe4fa-fdb6-4768-8b96-cb81d9309cde" />

수정후 
- 처음 최신 뉴스 5개 초기화
<img width="1263" height="711" alt="image" src="https://github.com/user-attachments/assets/3a0dfe1a-4343-49b7-bdf3-324774ff2f25" />
- 10분 뒤 2개 초기화
<img width="1263" height="711" alt="image" src="https://github.com/user-attachments/assets/bfed4597-487a-4e02-b31f-9ddd1732c69a" />


---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
