### PR TITLE
Refactor: 미션(퀴즈/뉴스) 분리 및 보안/데이터 구조 개선

### DIFF
--- a/src/main/java/com/antmillion/main/controller/MainController.java
+++ b/src/main/java/com/antmillion/main/controller/MainController.java
@@ -2,6 +2,8 @@ package com.antmillion.main.controller;
 
 import com.antmillion.mission.service.MissionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,12 +18,24 @@ public class MainController {
 
     @GetMapping
     public String mainPage(Model model) {
-        Long userId =  missionService.getCurrentUserId();
+        Long userId =  currentUserId();
         boolean missionCompleted = false;
         if (userId != null) {
             missionCompleted = missionService.isTodayMissionCompleted(userId);
         }
         model.addAttribute("missionCompleted", missionCompleted);
         return "main/main";
+    }
+
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return null;
+        }
+        try {
+            return Long.valueOf(auth.getPrincipal().toString());
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/antmillion/mission/controller/MissionController.java
+++ b/src/main/java/com/antmillion/mission/controller/MissionController.java
@@ -1,73 +1,31 @@
 package com.antmillion.mission.controller;
 
-import com.antmillion.mission.dto.QuizQuestionResponseDTO;
-import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
-import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
 import com.antmillion.mission.service.MissionService;
 import com.antmillion.user.dto.UserRankResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 @Controller
-@RequestMapping("/mission")
 @RequiredArgsConstructor
 public class MissionController {
 
     private final MissionService missionService;
 
-    @GetMapping
+    @GetMapping("/mission")
     public String missionPage() {
         return "mission/mission";
     }
 
-    @GetMapping("/quiz")
-    public String quizPage() {
-        return "mission/quiz";
-    }
-
-    @GetMapping("/daily")
+    @GetMapping("/api/mission/user-rank")
     @ResponseBody
-    public List<QuizQuestionResponseDTO> getDailyQuizData() {
-        try {
-            return missionService.getDailyQuiz();
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            System.err.println("퀴즈 조회 중 오류: " + e.getMessage());
-            e.printStackTrace();
-            return new ArrayList<>();
-        }
-    }
-
-    @PostMapping("/check")
-    @ResponseBody
-    public QuizSubmissionResponseDTO checkAnswer(@RequestBody QuizSubmissionRequestDTO requestDTO) {
-        try {
-            return missionService.checkAndLogAnswer(requestDTO);
-        } catch (Exception e) {
-            System.err.println("퀴즈 채점 중 오류: " + e.getMessage());
-            e.printStackTrace();
-            return QuizSubmissionResponseDTO.builder()
-                    .isCorrect(false)
-                    .point(0)
-                    .message("오류가 발생했습니다. 다시 시도해주세요.")
-                    .build();
-        }
-    }
-
-    @GetMapping("/status")
-    @ResponseBody
-    public UserRankResponseDTO getMissionStatus() {
+    public UserRankResponseDTO getUserRankInfo() {
         Long userId = missionService.getCurrentUserId();
-        return missionService.getUserMissionStatus(userId);
+        return missionService.getUserRankInfo(userId);
     }
 
-    @GetMapping("/today-status")
+    @GetMapping("/api/mission/today-progress")
     @ResponseBody
     public Map<String, Object> getTodayMissionStatus() {
         Long userId = missionService.getCurrentUserId();

--- a/src/main/java/com/antmillion/mission/controller/MissionController.java
+++ b/src/main/java/com/antmillion/mission/controller/MissionController.java
@@ -1,11 +1,13 @@
 package com.antmillion.mission.controller;
 
+import com.antmillion.mission.dto.MissionStatusResponseDTO;
 import com.antmillion.mission.service.MissionService;
 import com.antmillion.user.dto.UserRankResponseDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
-import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -21,14 +23,32 @@ public class MissionController {
     @GetMapping("/api/mission/user-rank")
     @ResponseBody
     public UserRankResponseDTO getUserRankInfo() {
-        Long userId = missionService.getCurrentUserId();
+        Long userId = currentUserId();
+        if (userId == null) {
+            return new UserRankResponseDTO();
+        }
         return missionService.getUserRankInfo(userId);
     }
 
     @GetMapping("/api/mission/today-progress")
     @ResponseBody
-    public Map<String, Object> getTodayMissionStatus() {
-        Long userId = missionService.getCurrentUserId();
+    public MissionStatusResponseDTO getTodayMissionStatus() {
+        Long userId = currentUserId();
+        if (userId == null) {
+            return new MissionStatusResponseDTO();
+        }
         return missionService.getTodayMissionStatus(userId);
+    }
+
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return null;
+        }
+        try {
+            return Long.valueOf(auth.getPrincipal().toString());
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/antmillion/mission/dto/MissionStatusResponseDTO.java
+++ b/src/main/java/com/antmillion/mission/dto/MissionStatusResponseDTO.java
@@ -10,6 +10,6 @@ public class MissionStatusResponseDTO {
     private int totalProgress;
     private int quizCount;
     private int newsCount;
-    private boolean isQuizCompleted;
-    private boolean isNewsCompleted;
+    private boolean QuizCompleted;
+    private boolean NewsCompleted;
 }

--- a/src/main/java/com/antmillion/mission/dto/MissionStatusResponseDTO.java
+++ b/src/main/java/com/antmillion/mission/dto/MissionStatusResponseDTO.java
@@ -1,0 +1,15 @@
+package com.antmillion.mission.dto;
+
+import lombok.*;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class MissionStatusResponseDTO {
+    private int totalProgress;
+    private int quizCount;
+    private int newsCount;
+    private boolean isQuizCompleted;
+    private boolean isNewsCompleted;
+}

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -1,17 +1,10 @@
 package com.antmillion.mission.service;
 
-import com.antmillion.mission.dto.QuizQuestionResponseDTO;
-import com.antmillion.mission.dto.QuizSubmissionRequestDTO;
-import com.antmillion.mission.dto.QuizSubmissionResponseDTO;
 import com.antmillion.user.dto.UserRankResponseDTO;
-
-import java.util.List;
 import java.util.Map;
 
 public interface MissionService {
-    List<QuizQuestionResponseDTO> getDailyQuiz();
-    QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO);
-    UserRankResponseDTO getUserMissionStatus(Long userId);
+    UserRankResponseDTO getUserRankInfo(Long userId);
     Long getCurrentUserId();
     boolean isTodayMissionCompleted(Long userId);
     Map<String, Object> getTodayMissionStatus(Long userId);

--- a/src/main/java/com/antmillion/mission/service/MissionService.java
+++ b/src/main/java/com/antmillion/mission/service/MissionService.java
@@ -1,11 +1,10 @@
 package com.antmillion.mission.service;
 
+import com.antmillion.mission.dto.MissionStatusResponseDTO;
 import com.antmillion.user.dto.UserRankResponseDTO;
-import java.util.Map;
 
 public interface MissionService {
     UserRankResponseDTO getUserRankInfo(Long userId);
-    Long getCurrentUserId();
     boolean isTodayMissionCompleted(Long userId);
-    Map<String, Object> getTodayMissionStatus(Long userId);
+    MissionStatusResponseDTO getTodayMissionStatus(Long userId);
 }

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -1,15 +1,12 @@
 package com.antmillion.mission.service;
 
+import com.antmillion.mission.dto.MissionStatusResponseDTO;
 import com.antmillion.quiz.mapper.QuizMapper;
 import com.antmillion.news.mapper.NewsMapper;
 import com.antmillion.user.dto.UserRankResponseDTO;
 import com.antmillion.user.service.AntRankService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import java.util.HashMap;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -17,15 +14,6 @@ public class MissionServiceImpl implements MissionService {
     private final QuizMapper quizMapper;
     private final AntRankService antRankService;
     private final NewsMapper newsMapper;
-
-    // 로그인한 유저 ID를 가져오는 메서드
-    public Long getCurrentUserId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
-            return Long.valueOf(auth.getPrincipal().toString());
-        }
-        return null;
-    }
 
     @Override
     public UserRankResponseDTO getUserRankInfo(Long userId) {
@@ -43,18 +31,20 @@ public class MissionServiceImpl implements MissionService {
     }
 
     public boolean isTodayMissionCompleted(Long userId) {
-        Map<String, Object> status = getTodayMissionStatus(userId);
+        MissionStatusResponseDTO status = getTodayMissionStatus(userId);
         // totalProgress가 100이면 완료로 간주
-        int progress = (int)status.get("totalProgress");
-        return progress >= 100;
+        return status.getTotalProgress() >= 100;
     }
 
-    public Map<String, Object> getTodayMissionStatus(Long userId) {
-        Map<String, Object> status = new HashMap<>();
-
+    public MissionStatusResponseDTO getTodayMissionStatus(Long userId) {
         if (userId == null) {
-            status.put("totalProgress", 0);
-            return status;
+            return MissionStatusResponseDTO.builder()
+                    .totalProgress(0)
+                    .quizCount(0)
+                    .newsCount(0)
+                    .isQuizCompleted(false)
+                    .isNewsCompleted(false)
+                    .build();
         }
 
         // 퀴즈 진행 상황
@@ -71,12 +61,12 @@ public class MissionServiceImpl implements MissionService {
         int totalProgress = quizScore + newsScore;
         totalProgress = Math.min(totalProgress, 100); // 100% 넘지 않게
 
-        // 데이터 담기
-        status.put("totalProgress", totalProgress);
-        status.put("quizCount", solvedQuizCount);
-        status.put("newsCount", readNewsCount);
-        status.put("isQuizCompleted", solvedQuizCount >= quizGoal);
-        status.put("isNewsCompleted", readNewsCount >= newsGoal);
-        return status;
+        return MissionStatusResponseDTO.builder()
+                .totalProgress(totalProgress)
+                .quizCount(solvedQuizCount)
+                .newsCount(readNewsCount)
+                .isQuizCompleted(solvedQuizCount >= quizGoal)
+                .isNewsCompleted(readNewsCount >= newsGoal)
+                .build();
     }
 }

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -42,8 +42,8 @@ public class MissionServiceImpl implements MissionService {
                     .totalProgress(0)
                     .quizCount(0)
                     .newsCount(0)
-                    .isQuizCompleted(false)
-                    .isNewsCompleted(false)
+                    .QuizCompleted(false)
+                    .NewsCompleted(false)
                     .build();
         }
 
@@ -65,8 +65,8 @@ public class MissionServiceImpl implements MissionService {
                 .totalProgress(totalProgress)
                 .quizCount(solvedQuizCount)
                 .newsCount(readNewsCount)
-                .isQuizCompleted(solvedQuizCount >= quizGoal)
-                .isNewsCompleted(readNewsCount >= newsGoal)
+                .QuizCompleted(solvedQuizCount >= quizGoal)
+                .NewsCompleted(readNewsCount >= newsGoal)
                 .build();
     }
 }

--- a/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
+++ b/src/main/java/com/antmillion/mission/service/MissionServiceImpl.java
@@ -1,8 +1,6 @@
 package com.antmillion.mission.service;
 
-import com.antmillion.auth.mapper.MemberMapper;
-import com.antmillion.mission.dto.*;
-import com.antmillion.mission.mapper.MissionMapper;
+import com.antmillion.quiz.mapper.QuizMapper;
 import com.antmillion.news.mapper.NewsMapper;
 import com.antmillion.user.dto.UserRankResponseDTO;
 import com.antmillion.user.service.AntRankService;
@@ -10,21 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class MissionServiceImpl implements MissionService {
-    private final MissionMapper missionMapper;
-    private final MemberMapper memberMapper;
+    private final QuizMapper quizMapper;
     private final AntRankService antRankService;
     private final NewsMapper newsMapper;
 
@@ -38,116 +28,7 @@ public class MissionServiceImpl implements MissionService {
     }
 
     @Override
-    public List<QuizQuestionResponseDTO> getDailyQuiz() {
-        Long userId = getCurrentUserId();
-
-        // 오늘 날짜 구하기 (yyyy-MM-dd)
-        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
-        // 오늘의 퀴즈 문제(Question) 조회
-        List<QuizQuestionDTO> questions = missionMapper.selectQuizByDate(today);
-
-        // 퀴즈가 없으면 빈 리스트 반환 (에러 방지)
-        if (questions.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        List<Long> solvedQuizIds = missionMapper.selectTodaySolvedQuizIds(userId);
-
-        // 안 푼 문제만 필터링
-        List<QuizQuestionDTO> unsolvedQuestions = questions.stream()
-                .filter(q -> !solvedQuizIds.contains(q.getQuizId()))
-                .collect(Collectors.toList());
-
-        // 오늘 미션 완료면 빈 리스트 반환 (에러 방지)
-        if (unsolvedQuestions.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        // 퀴즈 ID들만 추출 (보기 조회를 위해)
-        List<Long> quizIds = unsolvedQuestions.stream()
-                .map(QuizQuestionDTO::getQuizId)
-                .collect(Collectors.toList());
-
-        // 해당 퀴즈들의 보기(Choice) 전체 조회
-        List<QuizChoiceDTO> choices = missionMapper.selectQuizChoicesByQuizIds(quizIds);
-
-        // 보기들을 quizId를 키(Key)로 하여 그룹화 (퀴즈 ID로 객관식 보기 찾기 가능)
-        Map<Long, List<QuizChoiceDTO>> choicesMap = choices.stream()
-                .collect(Collectors.groupingBy(QuizChoiceDTO::getQuizId));
-
-        // 결과 DTO (Question + Choices)
-        List<QuizQuestionResponseDTO> responseList = new ArrayList<>();
-
-        for (QuizQuestionDTO q : unsolvedQuestions) {
-            // 해당 문제의 보기 리스트 가져오기 (없으면 빈 리스트)
-            List<QuizChoiceDTO> quizChoices = choicesMap.getOrDefault(q.getQuizId(), new ArrayList<>());
-
-            // ResponseDTO 생성
-            QuizQuestionResponseDTO responseDTO = QuizQuestionResponseDTO.builder()
-                    .quizId(q.getQuizId())
-                    .type(q.getType())
-                    .question(q.getQuestion())
-                    .point(q.getPoint())
-                    .quizDate(q.getQuizDate())
-                    .choices(quizChoices)
-                    .build();
-            responseList.add(responseDTO);
-        }
-        return responseList;
-    }
-
-    @Override
-    @Transactional
-    public QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO) {
-        // 해당 퀴즈의 정답 조회
-        QuizResultDTO resultInfo = missionMapper.selectQuizResultByQuizId(requestDTO.getQuizId());
-        if (resultInfo == null || resultInfo.getAnswer() == null) {
-            throw new IllegalArgumentException("존재하지 않는 퀴즈입니다.");
-        }
-
-        // 채점
-        boolean isCorrect = resultInfo.getAnswer().equals(requestDTO.getChoiceNo());
-        if(isCorrect) {
-            try {
-                int count = missionMapper.countSolvedHistory(requestDTO.getUserId(), requestDTO.getQuizId());
-                if (count == 0) {
-                    QuizLogDTO logDTO = QuizLogDTO.builder()
-                            .userId(requestDTO.getUserId())
-                            .quizId(requestDTO.getQuizId())
-                            .build();
-                    missionMapper.insertQuizLog(logDTO);
-
-                    // 포인트 지급
-                    memberMapper.updateUserPoint(requestDTO.getUserId(), resultInfo.getPoint());
-
-                    // 랭크 갱신
-                    Long userId = requestDTO.getUserId();
-                    int newPoint = memberMapper.selectUserPoint(userId);
-                    antRankService.updateUserRank(userId, newPoint);
-                }
-                // 정답 응답
-                return QuizSubmissionResponseDTO.builder()
-                        .isCorrect(true)
-                        .point(resultInfo.getPoint())
-                        .message(resultInfo.getExplanation())
-                        .build();
-            } catch (Exception e) {
-                System.err.println("퀴즈 로그 저장 중 오류: " + e.getMessage());
-                e.printStackTrace();
-                throw new RuntimeException("퀴즈 처리 중 오류가 발생했습니다.", e);
-            }
-        }
-        // 오답 응답
-        return QuizSubmissionResponseDTO.builder()
-                .isCorrect(false)
-                .point(0)
-                .message("다시 한번 생각해 보세요.")
-                .build();
-    }
-
-    @Override
-    public UserRankResponseDTO getUserMissionStatus(Long userId) {
+    public UserRankResponseDTO getUserRankInfo(Long userId) {
         if (userId == null) {
             throw new IllegalArgumentException("사용자 ID가 필요합니다.");
         }
@@ -177,7 +58,7 @@ public class MissionServiceImpl implements MissionService {
         }
 
         // 퀴즈 진행 상황
-        int solvedQuizCount = missionMapper.countTodaySolvedQuiz(userId);
+        int solvedQuizCount = quizMapper.countTodaySolvedQuiz(userId);
         int quizGoal = 2;
 
         // 뉴스 진행 상황

--- a/src/main/java/com/antmillion/naver/controller/NaverNewsController.java
+++ b/src/main/java/com/antmillion/naver/controller/NaverNewsController.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/news")
+@RequestMapping("/api/naver/news")
 public class NaverNewsController {
 
     private final NaverNewsService naverNewsService;
@@ -44,34 +44,5 @@ public class NaverNewsController {
         response.put("maxPage", newsResponse.getMaxPage());   // 마지막 페이지 번호
         response.put("readList", readList);                   // 내가 읽은 URL 리스트 (String 배열)
         return ResponseEntity.ok(response);
-    }
-
-    // 뉴스 읽기 및 포인트 적립
-    @PostMapping("/read")
-    public ResponseEntity<Map<String, Object>> readNews(@RequestBody Map<String, String> payload) {
-        Long userId = missionService.getCurrentUserId();
-
-        // 비로그인 상태면 null -> 401 에러 처리
-        if (userId == null) {
-            return ResponseEntity.status(401).build();
-        }
-
-        String newsUrl = payload.get("newsUrl");
-        Map<String, Object> result = newsService.readNews(userId, newsUrl);
-        return ResponseEntity.ok(result);
-    }
-
-    // 현재 달성률 조회
-    @GetMapping("/progress")
-    public ResponseEntity<Map<String, Object>> getProgress() {
-        Long userId = missionService.getCurrentUserId();
-
-        // 비로그인 상태면 0%로 응답
-        if (userId == null) {
-            return ResponseEntity.ok(Map.of("progress", 0, "readCount", 0));
-        }
-
-        Map<String, Object> result = newsService.getMissionProgress(userId);
-        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/antmillion/naver/controller/NaverNewsController.java
+++ b/src/main/java/com/antmillion/naver/controller/NaverNewsController.java
@@ -1,17 +1,17 @@
 package com.antmillion.naver.controller;
 
-import com.antmillion.mission.service.MissionService;
+import com.antmillion.naver.dto.NaverNewsListResponseDTO;
 import com.antmillion.naver.dto.PagedNewsResponseDTO;
 import com.antmillion.naver.service.NaverNewsService;
 import com.antmillion.news.service.NewsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,10 +20,9 @@ public class NaverNewsController {
 
     private final NaverNewsService naverNewsService;
     private final NewsService newsService;
-    private final MissionService missionService;
 
     @GetMapping
-    public ResponseEntity<Map<String, Object>> getNews (
+    public ResponseEntity<NaverNewsListResponseDTO> getNews (
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "5") int size
     ){
@@ -31,18 +30,31 @@ public class NaverNewsController {
         PagedNewsResponseDTO newsResponse = naverNewsService.getNews(page, size);
 
         // 사용자 아이디 가져오기
-        Long userId = missionService.getCurrentUserId();
+        Long userId = currentUserId();
 
         // 오늘 읽은 URL 목록 가져오기 (비로그인이면 빈 리스트)
         List<String> readList = (userId != null) ? newsService.selectTodayReadUrls(userId) : new ArrayList<>();
 
-        // 합쳐서 보내기
-        Map<String, Object> response = new HashMap<>();
-        response.put("articles", newsResponse.getArticles()); // 네이버 뉴스 리스트
-        response.put("totalCount", newsResponse.getTotalCount()); // 전체 뉴스 개수
-        response.put("currentPage", newsResponse.getCurrentPage()); // 조회중인 페이지 번호
-        response.put("maxPage", newsResponse.getMaxPage());   // 마지막 페이지 번호
-        response.put("readList", readList);                   // 내가 읽은 URL 리스트 (String 배열)
+        // 응답 DTO 생성 (뉴스 데이터 + 읽은 목록 합치기)
+        NaverNewsListResponseDTO response = NaverNewsListResponseDTO.builder()
+                .articles(newsResponse.getArticles())
+                .totalCount(newsResponse.getTotalCount())
+                .currentPage(newsResponse.getCurrentPage())
+                .maxPage(newsResponse.getMaxPage())
+                .readList(readList) // 여기에 읽은 목록 추가!
+                .build();
         return ResponseEntity.ok(response);
+    }
+
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return null;
+        }
+        try {
+            return Long.valueOf(auth.getPrincipal().toString());
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/antmillion/naver/dto/NaverNewsListResponseDTO.java
+++ b/src/main/java/com/antmillion/naver/dto/NaverNewsListResponseDTO.java
@@ -1,0 +1,17 @@
+package com.antmillion.naver.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NaverNewsListResponseDTO {
+    private List<NaverNewsItemDTO> articles; // 뉴스 리스트
+    private int totalCount;                  // 전체 개수
+    private int currentPage;                 // 현재 페이지
+    private int maxPage;                     // 마지막 페이지
+    private List<String> readList;           // 내가 읽은 URL 목록
+}

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -33,6 +33,9 @@ public class NaverNewsService {
     // 메모리 뉴스 저장소 (최신순)
     private final List<NaverNewsItemDTO> newsList = Collections.synchronizedList(new ArrayList<>());
 
+    private static final DateTimeFormatter NAVER_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
+
     // 서버 시작 시 초기화
     @PostConstruct
     public void init() {
@@ -64,8 +67,6 @@ public class NaverNewsService {
             return;
         }
 
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
-
         synchronized (newsList) {
             // 기존 링크 스냅샷 및 현재 저장된 가장 최신 시간 계산
             Set<String> existingLinks = newsList.stream()
@@ -76,7 +77,7 @@ public class NaverNewsService {
             Optional<ZonedDateTime> currentNewest = newsList.stream()
                     .map(NaverNewsItemDTO::getPubDate)
                     .filter(Objects::nonNull)
-                    .map(s -> parsePubDate(s, formatter))
+                    .map(s -> parsePubDate(s, NAVER_DATE_FORMATTER))
                     .filter(Objects::nonNull)
                     .max(Comparator.naturalOrder());
 
@@ -85,13 +86,18 @@ public class NaverNewsService {
                     .filter(item -> item.getLink() != null && item.getPubDate() != null)
                     .filter(item -> !existingLinks.contains(item.getLink()))
                     .filter(item -> {
-                        ZonedDateTime itemDt = parsePubDate(item.getPubDate(), formatter);
+                        ZonedDateTime itemDt = parsePubDate(item.getPubDate(), NAVER_DATE_FORMATTER);
                         if (itemDt == null) return false;
-                        return currentNewest.map(cur -> itemDt.isAfter(cur)).orElse(true);
+                        if (currentNewest.isPresent()) {
+                            ZonedDateTime cur = currentNewest.get();
+                            return itemDt.isAfter(cur);
+                        } else {
+                            return true;
+                        }
                     })
                     .sorted((a, b) -> {
-                        ZonedDateTime da = parsePubDate(a.getPubDate(), formatter);
-                        ZonedDateTime db = parsePubDate(b.getPubDate(), formatter);
+                        ZonedDateTime da = parsePubDate(a.getPubDate(), NAVER_DATE_FORMATTER);
+                        ZonedDateTime db = parsePubDate(b.getPubDate(), NAVER_DATE_FORMATTER);
                         if (da == null || db == null) return 0;
                         return db.compareTo(da); // 최신순
                     })
@@ -121,14 +127,10 @@ public class NaverNewsService {
     // 뉴스 조회 (페이지네이션)
     public PagedNewsResponseDTO getNews(int page, int size) {
         synchronized (newsList) {
-            // 리스트를 내보내기 전에 최신순으로 정렬
-            // 네이버 뉴스 날짜 포맷: Tue, 28 Jan 2026 15:06:00 +0900
-            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
-
             newsList.sort((o1, o2) -> {
                 try {
-                    ZonedDateTime t1 = ZonedDateTime.parse(o1.getPubDate(), formatter);
-                    ZonedDateTime t2 = ZonedDateTime.parse(o2.getPubDate(), formatter);
+                    ZonedDateTime t1 = ZonedDateTime.parse(o1.getPubDate(), NAVER_DATE_FORMATTER);
+                    ZonedDateTime t2 = ZonedDateTime.parse(o2.getPubDate(), NAVER_DATE_FORMATTER);
                     return t2.compareTo(t1); // t2가 더 크면(최신이면) 앞으로 -> 내림차순
                 } catch (Exception e) {
                     return 0;
@@ -137,14 +139,13 @@ public class NaverNewsService {
 
             int totalCount = newsList.size();
             int start = (page - 1) * size;
-            int end = Math.min(start + size, totalCount);
 
-            List<NaverNewsItemDTO> paged;
             if (start >= totalCount) {
-                paged = Collections.emptyList();
-            } else {
-                paged = new ArrayList<>(newsList.subList(start, end));
+                return new PagedNewsResponseDTO(Collections.emptyList(), totalCount, page, 0);
             }
+
+            int end = Math.min(start + size, totalCount);
+            List<NaverNewsItemDTO> paged = newsList.subList(start, end);
             return new PagedNewsResponseDTO(
                     paged,
                     totalCount,
@@ -190,7 +191,6 @@ public class NaverNewsService {
         } catch (Exception e) {
             log.error("네이버 뉴스 API 호출 실패", e);
         }
-
         return Collections.emptyList();
     }
 }

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -42,34 +42,79 @@ public class NaverNewsService {
     private void initNews() {
         List<NaverNewsItemDTO> fetched = fetchFromNaverNewsApi(50);
         newsList.clear();
-        newsList.addAll(
-                fetched.stream()
-                        .limit(5)
-                        .collect(Collectors.toList())
-        );
+        List<NaverNewsItemDTO> initial = fetched.stream()
+                .limit(5)
+                .collect(Collectors.toList());
+        newsList.addAll(initial);
+
+        if (initial.isEmpty()) {
+            log.info("초기화될 뉴스가 없습니다.");
+        } else {
+            log.info("처음 뉴스 {}개 조회", initial.size());
+        }
     }
 
     // 1시간마다 최신 2개 추가
     @Scheduled(initialDelay = 60 * 60 * 1000, fixedRate = 60 * 60 * 1000)
     public void appendHourlyNews() {
-        if (newsList.isEmpty()) {
-            initNews();
+        // 네이버 API 호출
+        List<NaverNewsItemDTO> latest = fetchFromNaverNewsApi(100);
+        if (latest.isEmpty()) {
+            log.info("네이버에서 가져온 뉴스가 없습니다.");
             return;
         }
 
-        List<NaverNewsItemDTO> latest = fetchFromNaverNewsApi(100);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
 
-        Set<String> existingLinks = newsList.stream()
-                .map(NaverNewsItemDTO::getLink)
-                .collect(Collectors.toSet());
+        synchronized (newsList) {
+            // 기존 링크 스냅샷 및 현재 저장된 가장 최신 시간 계산
+            Set<String> existingLinks = newsList.stream()
+                    .map(NaverNewsItemDTO::getLink)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toSet());
 
-        List<NaverNewsItemDTO> newItems = latest.stream()
-                .filter(item -> !existingLinks.contains(item.getLink()))
-                .limit(2)
-                .collect(Collectors.toList());
+            Optional<ZonedDateTime> currentNewest = newsList.stream()
+                    .map(NaverNewsItemDTO::getPubDate)
+                    .filter(Objects::nonNull)
+                    .map(s -> parsePubDate(s, formatter))
+                    .filter(Objects::nonNull)
+                    .max(Comparator.naturalOrder());
 
-        if (!newItems.isEmpty()) {
-            newsList.addAll(0, newItems);
+            // latest에서 링크 중복 제거 + pubDate가 현재 저장된 최신보다 이후인 것만 선택
+            List<NaverNewsItemDTO> candidates = latest.stream()
+                    .filter(item -> item.getLink() != null && item.getPubDate() != null)
+                    .filter(item -> !existingLinks.contains(item.getLink()))
+                    .filter(item -> {
+                        ZonedDateTime itemDt = parsePubDate(item.getPubDate(), formatter);
+                        if (itemDt == null) return false;
+                        return currentNewest.map(cur -> itemDt.isAfter(cur)).orElse(true);
+                    })
+                    .sorted((a, b) -> {
+                        ZonedDateTime da = parsePubDate(a.getPubDate(), formatter);
+                        ZonedDateTime db = parsePubDate(b.getPubDate(), formatter);
+                        if (da == null || db == null) return 0;
+                        return db.compareTo(da); // 최신순
+                    })
+                    .limit(2)
+                    .collect(Collectors.toList());
+
+            if (!candidates.isEmpty()) {
+                newsList.addAll(0, candidates);
+                log.info("뉴스 {}개가 추가되었습니다. 총 뉴스 {}개", candidates.size(), newsList.size());
+                candidates.forEach(it -> log.debug("추가된 뉴스: title='{}' link='{}' pubDate='{}'", it.getTitle(), it.getLink(), it.getPubDate()));
+            } else {
+                log.info("추가될 뉴스가 없습니다.");
+            }
+        }
+    }
+
+    private ZonedDateTime parsePubDate(String pubDateStr, DateTimeFormatter formatter) {
+        if (pubDateStr == null) return null;
+        try {
+            return ZonedDateTime.parse(pubDateStr, formatter);
+        } catch (Exception e) {
+            log.debug("pubDate 파싱 실패: {}", pubDateStr);
+            return null;
         }
     }
 

--- a/src/main/java/com/antmillion/naver/service/NaverNewsService.java
+++ b/src/main/java/com/antmillion/naver/service/NaverNewsService.java
@@ -50,7 +50,7 @@ public class NaverNewsService {
     }
 
     // 1시간마다 최신 2개 추가
-    @Scheduled(fixedRate = 60 * 60 * 1000)
+    @Scheduled(initialDelay = 60 * 60 * 1000, fixedRate = 60 * 60 * 1000)
     public void appendHourlyNews() {
         if (newsList.isEmpty()) {
             initNews();

--- a/src/main/java/com/antmillion/news/controller/NewsController.java
+++ b/src/main/java/com/antmillion/news/controller/NewsController.java
@@ -1,9 +1,11 @@
 package com.antmillion.news.controller;
 
-import com.antmillion.mission.service.MissionService;
+import com.antmillion.news.dto.NewsProgressResponseDTO;
 import com.antmillion.news.service.NewsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,7 +16,6 @@ import java.util.Map;
 public class NewsController {
 
     private final NewsService newsService;
-    private final MissionService missionService;
 
     @GetMapping("/news")
     public String newsPage() {
@@ -24,8 +25,8 @@ public class NewsController {
     // 뉴스 읽기 및 포인트 적립
     @PostMapping("/api/mission/news/read")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> readNews(@RequestBody Map<String, String> payload) {
-        Long userId = missionService.getCurrentUserId();
+    public ResponseEntity<NewsProgressResponseDTO> readNews(@RequestBody Map<String, String> payload) {
+        Long userId = currentUserId();
 
         // 비로그인 상태면 null -> 401 에러 처리
         if (userId == null) {
@@ -33,22 +34,33 @@ public class NewsController {
         }
 
         String newsUrl = payload.get("newsUrl");
-        Map<String, Object> result = newsService.readNews(userId, newsUrl);
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(newsService.readNews(userId, newsUrl));
     }
 
     // 현재 달성률 조회
     @GetMapping("/api/mission/news/progress")
     @ResponseBody
-    public ResponseEntity<Map<String, Object>> getProgress() {
-        Long userId = missionService.getCurrentUserId();
+    public ResponseEntity<NewsProgressResponseDTO> getProgress() {
+        Long userId = currentUserId();
 
-        // 비로그인 상태면 0%로 응답
         if (userId == null) {
-            return ResponseEntity.ok(Map.of("progress", 0, "readCount", 0));
+            return ResponseEntity.ok(NewsProgressResponseDTO.builder()
+                    .progress(0)
+                    .readCount(0)
+                    .build());
         }
+        return ResponseEntity.ok(newsService.getMissionProgress(userId));
+    }
 
-        Map<String, Object> result = newsService.getMissionProgress(userId);
-        return ResponseEntity.ok(result);
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return null;
+        }
+        try {
+            return Long.valueOf(auth.getPrincipal().toString());
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/antmillion/news/controller/NewsController.java
+++ b/src/main/java/com/antmillion/news/controller/NewsController.java
@@ -1,14 +1,54 @@
 package com.antmillion.news.controller;
 
+import com.antmillion.mission.service.MissionService;
+import com.antmillion.news.service.NewsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Controller
-@RequestMapping("/news")
+@RequiredArgsConstructor
 public class NewsController {
-    @GetMapping
-    public String getTodayNewsFeed() {
-        return "/news/news";
+
+    private final NewsService newsService;
+    private final MissionService missionService;
+
+    @GetMapping("/news")
+    public String newsPage() {
+        return "news/news";
+    }
+
+    // 뉴스 읽기 및 포인트 적립
+    @PostMapping("/api/mission/news/read")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> readNews(@RequestBody Map<String, String> payload) {
+        Long userId = missionService.getCurrentUserId();
+
+        // 비로그인 상태면 null -> 401 에러 처리
+        if (userId == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        String newsUrl = payload.get("newsUrl");
+        Map<String, Object> result = newsService.readNews(userId, newsUrl);
+        return ResponseEntity.ok(result);
+    }
+
+    // 현재 달성률 조회
+    @GetMapping("/api/mission/news/progress")
+    @ResponseBody
+    public ResponseEntity<Map<String, Object>> getProgress() {
+        Long userId = missionService.getCurrentUserId();
+
+        // 비로그인 상태면 0%로 응답
+        if (userId == null) {
+            return ResponseEntity.ok(Map.of("progress", 0, "readCount", 0));
+        }
+
+        Map<String, Object> result = newsService.getMissionProgress(userId);
+        return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/antmillion/news/dto/NewsProgressResponseDTO.java
+++ b/src/main/java/com/antmillion/news/dto/NewsProgressResponseDTO.java
@@ -1,0 +1,13 @@
+package com.antmillion.news.dto;
+
+import lombok.*;
+
+@Getter@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class NewsProgressResponseDTO {
+    private int readCount;       // 오늘 읽은 개수
+    private int progress;        // 달성률
+    private Integer earnedPoint; // 획득 포인트 (읽기 요청 시에만 포함)
+}

--- a/src/main/java/com/antmillion/news/service/NewsService.java
+++ b/src/main/java/com/antmillion/news/service/NewsService.java
@@ -1,10 +1,10 @@
 package com.antmillion.news.service;
 
+import com.antmillion.news.dto.NewsProgressResponseDTO;
 import java.util.List;
-import java.util.Map;
 
 public interface NewsService {
-    Map<String, Object> readNews(Long userId, String newsUrl);
-    Map<String, Object> getMissionProgress(Long userId);
+    NewsProgressResponseDTO readNews(Long userId, String newsUrl);
+    NewsProgressResponseDTO getMissionProgress(Long userId);
     List<String> selectTodayReadUrls(Long userId);
 }

--- a/src/main/java/com/antmillion/news/service/NewsServiceImpl.java
+++ b/src/main/java/com/antmillion/news/service/NewsServiceImpl.java
@@ -2,14 +2,13 @@ package com.antmillion.news.service;
 
 import com.antmillion.auth.mapper.MemberMapper;
 import com.antmillion.news.dto.NewsLogDTO;
+import com.antmillion.news.dto.NewsProgressResponseDTO;
 import com.antmillion.news.mapper.NewsMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +19,7 @@ public class NewsServiceImpl implements NewsService {
 
     // 뉴스 클릭 처리 및 현재 달성률 반환
     @Transactional
-    public Map<String, Object> readNews(Long userId, String newsUrl) {
+    public NewsProgressResponseDTO readNews(Long userId, String newsUrl) {
         // 중복 체크 (오늘 이미 읽은 기사인지)
         boolean alreadyRead = newsMapper.existsTodayLog(userId, newsUrl);
         int earnedPoint = 0; // 뉴스 획득 포인트
@@ -43,24 +42,28 @@ public class NewsServiceImpl implements NewsService {
             }
         }
 
-        // 5. 달성률 계산 및 결과 반환
-        Map<String, Object> response = getMissionProgress(userId);
-        response.put("earnedPoint", earnedPoint); // 화면에 포인트 적립 알림 띄우기 위해 추가
-        return response;
+        // 현재 상태 조회 (DTO 반환됨)
+        NewsProgressResponseDTO currentStatus = getMissionProgress(userId);
+
+        // 기존 상태에 earnedPoint만 추가해서
+        return NewsProgressResponseDTO.builder()
+                .readCount(currentStatus.getReadCount())
+                .progress(currentStatus.getProgress())
+                .earnedPoint(earnedPoint) // 포인트 정보 추가
+                .build();
     }
 
     // 현재 미션 달성률 조회 (페이지 로딩용)
-    public Map<String, Object> getMissionProgress(Long userId) {
+    public NewsProgressResponseDTO getMissionProgress(Long userId) {
         int count = newsMapper.countTodayNewsRead(userId);
 
         // 1개당 20%
         int progress = Math.min(count * 20, 100);
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("readCount", count);     // 읽은 개수
-        response.put("progress", progress);   // 달성률 (%)
-
-        return response;
+        return NewsProgressResponseDTO.builder()
+                .readCount(count)
+                .progress(progress)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/antmillion/quiz/controller/QuizController.java
+++ b/src/main/java/com/antmillion/quiz/controller/QuizController.java
@@ -5,6 +5,8 @@ import com.antmillion.quiz.dto.QuizSubmissionRequestDTO;
 import com.antmillion.quiz.dto.QuizSubmissionResponseDTO;
 import com.antmillion.quiz.service.QuizService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,30 +27,32 @@ public class QuizController {
     @GetMapping("/api/mission/quiz/daily")
     @ResponseBody
     public List<QuizQuestionResponseDTO> getDailyQuizData() {
-        try {
-            return quizService.getDailyQuiz();
-        } catch (IllegalStateException e) {
-            throw e;
-        } catch (Exception e) {
-            System.err.println("퀴즈 조회 중 오류: " + e.getMessage());
-            e.printStackTrace();
-            return new ArrayList<>();
+        Long userId = currentUserId(); // 1. 여기서 ID 꺼내기
+        if (userId == null) {
+            return new ArrayList<>(); // 비로그인이면 빈 리스트
         }
+        return quizService.getDailyQuiz(userId);
     }
 
     @PostMapping("/api/mission/quiz/check")
     @ResponseBody
     public QuizSubmissionResponseDTO checkAnswer(@RequestBody QuizSubmissionRequestDTO requestDTO) {
+        Long userId = currentUserId();
+        if (userId == null) {
+            return QuizSubmissionResponseDTO.builder().isCorrect(false).message("로그인이 필요합니다.").build();
+        }
+        return quizService.checkAndLogAnswer(userId, requestDTO);
+    }
+
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            return null;
+        }
         try {
-            return quizService.checkAndLogAnswer(requestDTO);
+            return Long.valueOf(auth.getPrincipal().toString());
         } catch (Exception e) {
-            System.err.println("퀴즈 채점 중 오류: " + e.getMessage());
-            e.printStackTrace();
-            return QuizSubmissionResponseDTO.builder()
-                    .isCorrect(false)
-                    .point(0)
-                    .message("오류가 발생했습니다. 다시 시도해주세요.")
-                    .build();
+            return null;
         }
     }
 }

--- a/src/main/java/com/antmillion/quiz/controller/QuizController.java
+++ b/src/main/java/com/antmillion/quiz/controller/QuizController.java
@@ -1,0 +1,54 @@
+package com.antmillion.quiz.controller;
+
+import com.antmillion.quiz.dto.QuizQuestionResponseDTO;
+import com.antmillion.quiz.dto.QuizSubmissionRequestDTO;
+import com.antmillion.quiz.dto.QuizSubmissionResponseDTO;
+import com.antmillion.quiz.service.QuizService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @GetMapping("/quiz")
+    public String quizPage() {
+        return "quiz/quiz";
+    }
+
+    @GetMapping("/api/mission/quiz/daily")
+    @ResponseBody
+    public List<QuizQuestionResponseDTO> getDailyQuizData() {
+        try {
+            return quizService.getDailyQuiz();
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            System.err.println("퀴즈 조회 중 오류: " + e.getMessage());
+            e.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+
+    @PostMapping("/api/mission/quiz/check")
+    @ResponseBody
+    public QuizSubmissionResponseDTO checkAnswer(@RequestBody QuizSubmissionRequestDTO requestDTO) {
+        try {
+            return quizService.checkAndLogAnswer(requestDTO);
+        } catch (Exception e) {
+            System.err.println("퀴즈 채점 중 오류: " + e.getMessage());
+            e.printStackTrace();
+            return QuizSubmissionResponseDTO.builder()
+                    .isCorrect(false)
+                    .point(0)
+                    .message("오류가 발생했습니다. 다시 시도해주세요.")
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/antmillion/quiz/dto/QuizChoiceDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizChoiceDTO.java
@@ -1,4 +1,4 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/antmillion/quiz/dto/QuizLogDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizLogDTO.java
@@ -1,4 +1,4 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/antmillion/quiz/dto/QuizQuestionDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizQuestionDTO.java
@@ -1,7 +1,6 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/antmillion/quiz/dto/QuizQuestionResponseDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizQuestionResponseDTO.java
@@ -1,4 +1,4 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/antmillion/quiz/dto/QuizResultDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizResultDTO.java
@@ -1,4 +1,4 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/antmillion/quiz/dto/QuizSubmissionRequestDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizSubmissionRequestDTO.java
@@ -7,7 +7,6 @@ import lombok.*;
 @AllArgsConstructor
 @ToString
 public class QuizSubmissionRequestDTO {
-    private Long userId;
     private Long quizId;
     private Integer choiceNo;
 }

--- a/src/main/java/com/antmillion/quiz/dto/QuizSubmissionRequestDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizSubmissionRequestDTO.java
@@ -1,4 +1,4 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import lombok.*;
 

--- a/src/main/java/com/antmillion/quiz/dto/QuizSubmissionResponseDTO.java
+++ b/src/main/java/com/antmillion/quiz/dto/QuizSubmissionResponseDTO.java
@@ -1,4 +1,4 @@
-package com.antmillion.mission.dto;
+package com.antmillion.quiz.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;

--- a/src/main/java/com/antmillion/quiz/mapper/QuizMapper.java
+++ b/src/main/java/com/antmillion/quiz/mapper/QuizMapper.java
@@ -1,16 +1,16 @@
-package com.antmillion.mission.mapper;
+package com.antmillion.quiz.mapper;
 
-import com.antmillion.mission.dto.QuizChoiceDTO;
-import com.antmillion.mission.dto.QuizLogDTO;
-import com.antmillion.mission.dto.QuizQuestionDTO;
-import com.antmillion.mission.dto.QuizResultDTO;
+import com.antmillion.quiz.dto.QuizChoiceDTO;
+import com.antmillion.quiz.dto.QuizLogDTO;
+import com.antmillion.quiz.dto.QuizQuestionDTO;
+import com.antmillion.quiz.dto.QuizResultDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
 @Mapper
-public interface MissionMapper {
+public interface QuizMapper {
     // 오늘의 퀴즈 조회
     List<QuizQuestionDTO> selectQuizByDate(@Param("quizDate") String quizDate);
 

--- a/src/main/java/com/antmillion/quiz/mapper/QuizMapper.java
+++ b/src/main/java/com/antmillion/quiz/mapper/QuizMapper.java
@@ -11,8 +11,7 @@ import java.util.List;
 
 @Mapper
 public interface QuizMapper {
-    // 오늘의 퀴즈 조회
-    List<QuizQuestionDTO> selectQuizByDate(@Param("quizDate") String quizDate);
+    List<QuizQuestionDTO> selectUnsolvedQuizByDate(@Param("userId") Long userId, @Param("quizDate") String quizDate);
 
     // 퀴즈 보기 조회 (quizId 기준)
     List<QuizChoiceDTO> selectQuizChoicesByQuizIds(@Param("quizIds") List<Long> quizIds);
@@ -22,9 +21,6 @@ public interface QuizMapper {
 
     // 퀴즈 풀이 이력 저장
     void insertQuizLog(QuizLogDTO quizLog);
-
-    // 어떤 문제를 풀었는지 확인
-    List<Long> selectTodaySolvedQuizIds(@Param("userId") Long userId);
 
     // 오늘 미션 완료 여부 조회
     int countTodaySolvedQuiz(@Param("userId") Long userId);

--- a/src/main/java/com/antmillion/quiz/service/QuizService.java
+++ b/src/main/java/com/antmillion/quiz/service/QuizService.java
@@ -1,0 +1,13 @@
+package com.antmillion.quiz.service;
+
+import com.antmillion.quiz.dto.QuizQuestionResponseDTO;
+import com.antmillion.quiz.dto.QuizSubmissionRequestDTO;
+import com.antmillion.quiz.dto.QuizSubmissionResponseDTO;
+
+import java.util.List;
+
+public interface QuizService {
+    Long getCurrentUserId();
+    List<QuizQuestionResponseDTO> getDailyQuiz();
+    QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO);
+}

--- a/src/main/java/com/antmillion/quiz/service/QuizService.java
+++ b/src/main/java/com/antmillion/quiz/service/QuizService.java
@@ -7,7 +7,6 @@ import com.antmillion.quiz.dto.QuizSubmissionResponseDTO;
 import java.util.List;
 
 public interface QuizService {
-    Long getCurrentUserId();
-    List<QuizQuestionResponseDTO> getDailyQuiz();
-    QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO);
+    List<QuizQuestionResponseDTO> getDailyQuiz(Long userId);
+    QuizSubmissionResponseDTO checkAndLogAnswer(Long userId, QuizSubmissionRequestDTO requestDTO);
 }

--- a/src/main/java/com/antmillion/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/antmillion/quiz/service/QuizServiceImpl.java
@@ -1,0 +1,144 @@
+package com.antmillion.quiz.service;
+
+import com.antmillion.auth.mapper.MemberMapper;
+import com.antmillion.quiz.dto.*;
+import com.antmillion.quiz.mapper.QuizMapper;
+import com.antmillion.user.service.AntRankService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class QuizServiceImpl implements QuizService {
+    private final QuizMapper quizMapper;
+    private final MemberMapper memberMapper;
+    private final AntRankService antRankService;
+
+    // 로그인한 유저 ID를 가져오는 메서드
+    public Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
+            return Long.valueOf(auth.getPrincipal().toString());
+        }
+        return null;
+    }
+
+    @Override
+    public List<QuizQuestionResponseDTO> getDailyQuiz() {
+        Long userId = getCurrentUserId();
+
+        // 오늘 날짜 구하기 (yyyy-MM-dd)
+        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        // 오늘의 퀴즈 문제(Question) 조회
+        List<QuizQuestionDTO> questions = quizMapper.selectQuizByDate(today);
+
+        // 퀴즈가 없으면 빈 리스트 반환 (에러 방지)
+        if (questions.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        List<Long> solvedQuizIds = quizMapper.selectTodaySolvedQuizIds(userId);
+
+        // 안 푼 문제만 필터링
+        List<QuizQuestionDTO> unsolvedQuestions = questions.stream()
+                .filter(q -> !solvedQuizIds.contains(q.getQuizId()))
+                .collect(Collectors.toList());
+
+        // 오늘 미션 완료면 빈 리스트 반환 (에러 방지)
+        if (unsolvedQuestions.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        // 퀴즈 ID들만 추출 (보기 조회를 위해)
+        List<Long> quizIds = unsolvedQuestions.stream()
+                .map(QuizQuestionDTO::getQuizId)
+                .collect(Collectors.toList());
+
+        // 해당 퀴즈들의 보기(Choice) 전체 조회
+        List<QuizChoiceDTO> choices = quizMapper.selectQuizChoicesByQuizIds(quizIds);
+
+        // 보기들을 quizId를 키(Key)로 하여 그룹화 (퀴즈 ID로 객관식 보기 찾기 가능)
+        Map<Long, List<QuizChoiceDTO>> choicesMap = choices.stream()
+                .collect(Collectors.groupingBy(QuizChoiceDTO::getQuizId));
+
+        // 결과 DTO (Question + Choices)
+        List<QuizQuestionResponseDTO> responseList = new ArrayList<>();
+
+        for (QuizQuestionDTO q : unsolvedQuestions) {
+            // 해당 문제의 보기 리스트 가져오기 (없으면 빈 리스트)
+            List<QuizChoiceDTO> quizChoices = choicesMap.getOrDefault(q.getQuizId(), new ArrayList<>());
+
+            // ResponseDTO 생성
+            QuizQuestionResponseDTO responseDTO = QuizQuestionResponseDTO.builder()
+                    .quizId(q.getQuizId())
+                    .type(q.getType())
+                    .question(q.getQuestion())
+                    .point(q.getPoint())
+                    .quizDate(q.getQuizDate())
+                    .choices(quizChoices)
+                    .build();
+            responseList.add(responseDTO);
+        }
+        return responseList;
+    }
+
+    @Override
+    @Transactional
+    public QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO) {
+        // 해당 퀴즈의 정답 조회
+        QuizResultDTO resultInfo = quizMapper.selectQuizResultByQuizId(requestDTO.getQuizId());
+        if (resultInfo == null || resultInfo.getAnswer() == null) {
+            throw new IllegalArgumentException("존재하지 않는 퀴즈입니다.");
+        }
+
+        // 채점
+        boolean isCorrect = resultInfo.getAnswer().equals(requestDTO.getChoiceNo());
+        if(isCorrect) {
+            try {
+                int count = quizMapper.countSolvedHistory(requestDTO.getUserId(), requestDTO.getQuizId());
+                if (count == 0) {
+                    QuizLogDTO logDTO = QuizLogDTO.builder()
+                            .userId(requestDTO.getUserId())
+                            .quizId(requestDTO.getQuizId())
+                            .build();
+                    quizMapper.insertQuizLog(logDTO);
+
+                    // 포인트 지급
+                    memberMapper.updateUserPoint(requestDTO.getUserId(), resultInfo.getPoint());
+
+                    // 랭크 갱신
+                    Long userId = requestDTO.getUserId();
+                    int newPoint = memberMapper.selectUserPoint(userId);
+                    antRankService.updateUserRank(userId, newPoint);
+                }
+                // 정답 응답
+                return QuizSubmissionResponseDTO.builder()
+                        .isCorrect(true)
+                        .point(resultInfo.getPoint())
+                        .message(resultInfo.getExplanation())
+                        .build();
+            } catch (Exception e) {
+                System.err.println("퀴즈 로그 저장 중 오류: " + e.getMessage());
+                e.printStackTrace();
+                throw new RuntimeException("퀴즈 처리 중 오류가 발생했습니다.", e);
+            }
+        }
+        // 오답 응답
+        return QuizSubmissionResponseDTO.builder()
+                .isCorrect(false)
+                .point(0)
+                .message("다시 한번 생각해 보세요.")
+                .build();
+    }
+}

--- a/src/main/java/com/antmillion/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/antmillion/quiz/service/QuizServiceImpl.java
@@ -24,25 +24,10 @@ public class QuizServiceImpl implements QuizService {
 
     @Override
     public List<QuizQuestionResponseDTO> getDailyQuiz(Long userId) {
-        // 오늘 날짜 구하기 (yyyy-MM-dd)
-        String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-
-        // 오늘의 퀴즈 문제(Question) 조회
-        List<QuizQuestionDTO> questions = quizMapper.selectQuizByDate(today);
+        // 오늘의 경제 퀴즈 문제(오늘 날짜 && 안 푼) 조회
+        List<QuizQuestionDTO> unsolvedQuestions = quizMapper.selectUnsolvedQuizByDate(userId, LocalDate.now().toString());
 
         // 퀴즈가 없으면 빈 리스트 반환 (에러 방지)
-        if (questions.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        List<Long> solvedQuizIds = quizMapper.selectTodaySolvedQuizIds(userId);
-
-        // 안 푼 문제만 필터링
-        List<QuizQuestionDTO> unsolvedQuestions = questions.stream()
-                .filter(q -> !solvedQuizIds.contains(q.getQuizId()))
-                .collect(Collectors.toList());
-
-        // 오늘 미션 완료면 빈 리스트 반환 (에러 방지)
         if (unsolvedQuestions.isEmpty()) {
             return new ArrayList<>();
         }
@@ -53,31 +38,19 @@ public class QuizServiceImpl implements QuizService {
                 .collect(Collectors.toList());
 
         // 해당 퀴즈들의 보기(Choice) 전체 조회
-        List<QuizChoiceDTO> choices = quizMapper.selectQuizChoicesByQuizIds(quizIds);
-
-        // 보기들을 quizId를 키(Key)로 하여 그룹화 (퀴즈 ID로 객관식 보기 찾기 가능)
-        Map<Long, List<QuizChoiceDTO>> choicesMap = choices.stream()
+        Map<Long, List<QuizChoiceDTO>> choicesMap = quizMapper.selectQuizChoicesByQuizIds(quizIds)
+                .stream()
                 .collect(Collectors.groupingBy(QuizChoiceDTO::getQuizId));
 
-        // 결과 DTO (Question + Choices)
-        List<QuizQuestionResponseDTO> responseList = new ArrayList<>();
-
-        for (QuizQuestionDTO q : unsolvedQuestions) {
-            // 해당 문제의 보기 리스트 가져오기 (없으면 빈 리스트)
-            List<QuizChoiceDTO> quizChoices = choicesMap.getOrDefault(q.getQuizId(), new ArrayList<>());
-
-            // ResponseDTO 생성
-            QuizQuestionResponseDTO responseDTO = QuizQuestionResponseDTO.builder()
-                    .quizId(q.getQuizId())
-                    .type(q.getType())
-                    .question(q.getQuestion())
-                    .point(q.getPoint())
-                    .quizDate(q.getQuizDate())
-                    .choices(quizChoices)
-                    .build();
-            responseList.add(responseDTO);
-        }
-        return responseList;
+        return unsolvedQuestions.stream().map(q -> QuizQuestionResponseDTO.builder()
+                .quizId(q.getQuizId())
+                .type(q.getType())
+                .question(q.getQuestion())
+                .point(q.getPoint())
+                .quizDate(q.getQuizDate())
+                .choices(choicesMap.getOrDefault(q.getQuizId(), new ArrayList<>()))
+                .build()
+        ).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/antmillion/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/antmillion/quiz/service/QuizServiceImpl.java
@@ -5,8 +5,6 @@ import com.antmillion.quiz.dto.*;
 import com.antmillion.quiz.mapper.QuizMapper;
 import com.antmillion.user.service.AntRankService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,19 +22,8 @@ public class QuizServiceImpl implements QuizService {
     private final MemberMapper memberMapper;
     private final AntRankService antRankService;
 
-    // 로그인한 유저 ID를 가져오는 메서드
-    public Long getCurrentUserId() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        if (auth != null && auth.isAuthenticated() && !"anonymousUser".equals(auth.getPrincipal())) {
-            return Long.valueOf(auth.getPrincipal().toString());
-        }
-        return null;
-    }
-
     @Override
-    public List<QuizQuestionResponseDTO> getDailyQuiz() {
-        Long userId = getCurrentUserId();
-
+    public List<QuizQuestionResponseDTO> getDailyQuiz(Long userId) {
         // 오늘 날짜 구하기 (yyyy-MM-dd)
         String today = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
@@ -95,7 +82,11 @@ public class QuizServiceImpl implements QuizService {
 
     @Override
     @Transactional
-    public QuizSubmissionResponseDTO checkAndLogAnswer(QuizSubmissionRequestDTO requestDTO) {
+    public QuizSubmissionResponseDTO checkAndLogAnswer(Long userId, QuizSubmissionRequestDTO requestDTO) {
+        if (userId == null) {
+            throw new IllegalStateException("로그인이 필요한 서비스입니다.");
+        }
+
         // 해당 퀴즈의 정답 조회
         QuizResultDTO resultInfo = quizMapper.selectQuizResultByQuizId(requestDTO.getQuizId());
         if (resultInfo == null || resultInfo.getAnswer() == null) {
@@ -106,19 +97,18 @@ public class QuizServiceImpl implements QuizService {
         boolean isCorrect = resultInfo.getAnswer().equals(requestDTO.getChoiceNo());
         if(isCorrect) {
             try {
-                int count = quizMapper.countSolvedHistory(requestDTO.getUserId(), requestDTO.getQuizId());
+                int count = quizMapper.countSolvedHistory(userId, requestDTO.getQuizId());
                 if (count == 0) {
                     QuizLogDTO logDTO = QuizLogDTO.builder()
-                            .userId(requestDTO.getUserId())
+                            .userId(userId)
                             .quizId(requestDTO.getQuizId())
                             .build();
                     quizMapper.insertQuizLog(logDTO);
 
                     // 포인트 지급
-                    memberMapper.updateUserPoint(requestDTO.getUserId(), resultInfo.getPoint());
+                    memberMapper.updateUserPoint(userId, resultInfo.getPoint());
 
                     // 랭크 갱신
-                    Long userId = requestDTO.getUserId();
                     int newPoint = memberMapper.selectUserPoint(userId);
                     antRankService.updateUserRank(userId, newPoint);
                 }

--- a/src/main/resources/mappers/quiz/QuizMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizMapper.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
-<mapper namespace="com.antmillion.mission.mapper.MissionMapper">
+<mapper namespace="com.antmillion.quiz.mapper.QuizMapper">
 
-    <resultMap id="quizQuestionMap" type="com.antmillion.mission.dto.QuizQuestionDTO">
+    <resultMap id="quizQuestionMap" type="com.antmillion.quiz.dto.QuizQuestionDTO">
         <id property="quizId" column="quiz_id"/>
         <result property="missionId" column="mission_id"/>
         <result property="type" column="type"/>
@@ -29,7 +29,7 @@
         ORDER BY quiz_id ASC
     </select>
 
-    <resultMap id="quizChoiceMap" type="com.antmillion.mission.dto.QuizChoiceDTO">
+    <resultMap id="quizChoiceMap" type="com.antmillion.quiz.dto.QuizChoiceDTO">
         <id property="quizChoiceId" column="quiz_choice_id"/>
         <result property="quizId" column="quiz_id"/>
         <result property="choiceNo" column="choice_no"/>
@@ -50,7 +50,7 @@
         ORDER BY quiz_id ASC, choice_no ASC
     </select>
 
-    <insert id="insertQuizLog" parameterType="com.antmillion.mission.dto.QuizLogDTO">
+    <insert id="insertQuizLog" parameterType="com.antmillion.quiz.dto.QuizLogDTO">
         INSERT INTO quiz_log (user_id, quiz_id, solved_at)
         VALUES (#{userId}, #{quizId}, NOW())
     </insert>
@@ -75,7 +75,7 @@
         AND DATE(solved_at) = CURDATE()
     </select>
 
-    <resultMap id="quizResultMap" type="com.antmillion.mission.dto.QuizResultDTO">
+    <resultMap id="quizResultMap" type="com.antmillion.quiz.dto.QuizResultDTO">
         <result property="answer" column="answer"/>
         <result property="explanation" column="explanation"/>
         <result property="point" column="point"/>

--- a/src/main/resources/mappers/quiz/QuizMapper.xml
+++ b/src/main/resources/mappers/quiz/QuizMapper.xml
@@ -14,19 +14,14 @@
         <result property="quizDate" column="quiz_date"/>
     </resultMap>
 
-    <select id="selectQuizByDate" resultMap="quizQuestionMap">
-        SELECT
-            quiz_id,
-            mission_id,
-            type,
-            question,
-            answer,
-            explanation,
-            point,
-            quiz_date
-        FROM quiz_question
-        WHERE DATE_FORMAT(quiz_date, '%Y-%m-%d') = #{quizDate}
-        ORDER BY quiz_id ASC
+    <select id="selectUnsolvedQuizByDate" resultMap="quizQuestionMap">
+        SELECT * FROM quiz_question q
+        WHERE DATE(q.quiz_date) = #{quizDate}
+          AND NOT EXISTS (
+            SELECT 1 FROM quiz_log l
+            WHERE l.quiz_id = q.quiz_id AND l.user_id = #{userId}
+            )
+        ORDER BY q.quiz_id ASC
     </select>
 
     <resultMap id="quizChoiceMap" type="com.antmillion.quiz.dto.QuizChoiceDTO">
@@ -59,13 +54,6 @@
         SELECT COUNT(*)
         FROM quiz_log
         WHERE user_id = #{userId} AND quiz_id = #{quizId}
-    </select>
-
-    <select id="selectTodaySolvedQuizIds" resultType="long">
-        SELECT quiz_id
-        FROM quiz_log
-        WHERE user_id = #{userId}
-        AND DATE_FORMAT(solved_at, '%Y-%m-%d') = CURDATE()
     </select>
 
     <select id="countTodaySolvedQuiz" resultType="int">

--- a/src/main/webapp/WEB-INF/views/mission/mission.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/mission.jsp
@@ -45,7 +45,7 @@
                             경제 지식도 쌓고 나의 개미 랭크도 높여보세요!</p>
                     </div>
                     <div class="mission-card-footer">
-                        <button class="mission-card-btn" id="quiz-start-btn" onclick="location.href='${cpath}/mission/quiz'">도전하기</button>
+                        <button class="mission-card-btn" id="quiz-start-btn" onclick="location.href='${cpath}/quiz'">도전하기</button>
                     </div>
                 </div>
 

--- a/src/main/webapp/WEB-INF/views/mission/mission.jsp
+++ b/src/main/webapp/WEB-INF/views/mission/mission.jsp
@@ -123,10 +123,6 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         const cpath = "${pageContext.request.contextPath}";
-        let currentUserId = null;
-        <c:if test="${not empty pageContext.request.userPrincipal}">
-        currentUserId = parseInt('${pageContext.request.userPrincipal.name}');
-        </c:if>
     </script>
     <script src="${cpath}/resources/js/mission/mission.js"></script>
 </div>

--- a/src/main/webapp/WEB-INF/views/quiz/quiz.jsp
+++ b/src/main/webapp/WEB-INF/views/quiz/quiz.jsp
@@ -69,10 +69,6 @@
 		<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 		<script>
 			const cpath = "${pageContext.request.contextPath}";
-			let currentUserId = null;
-			<c:if test="${not empty pageContext.request.userPrincipal}">
-			currentUserId = parseInt('${pageContext.request.userPrincipal.name}');
-			</c:if>
 		</script>
 		<script src="${cpath}/resources/js/quiz/quiz.js"></script>
 	</div>

--- a/src/main/webapp/WEB-INF/views/quiz/quiz.jsp
+++ b/src/main/webapp/WEB-INF/views/quiz/quiz.jsp
@@ -5,7 +5,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>똑똑한개미 - 미션</title>
+<title>똑똑한개미 - 퀴즈</title>
 <%@ include file="/WEB-INF/views/common/common.jsp"%>
 <link rel="stylesheet" href="${cpath}/resources/css/mission/quiz.css">
 <link rel="stylesheet" href="${cpath}/resources/css/common/sidebar.css">
@@ -74,7 +74,7 @@
 			currentUserId = parseInt('${pageContext.request.userPrincipal.name}');
 			</c:if>
 		</script>
-		<script src="${cpath}/resources/js/mission/quiz.js"></script>
+		<script src="${cpath}/resources/js/quiz/quiz.js"></script>
 	</div>
 </body>
 </html>

--- a/src/main/webapp/resources/css/news/news.css
+++ b/src/main/webapp/resources/css/news/news.css
@@ -144,8 +144,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    max-width: 1200px;
-    margin: 0 auto;
+    width: 100%;
 }
 
 .news-card {

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -24,7 +24,7 @@ $(document).ready(function() {
 // 오늘의 미션 달성률(퀴즈/뉴스) 조회
 function checkMissionStatus() {
     $.ajax({
-        url: cpath + '/mission/today-status',
+        url: cpath + '/api/mission/today-progress',
         method: 'GET',
         success: function(data) {
             // 전체 진행률 업데이트 (서버에서 계산된 totalProgress 사용)
@@ -74,7 +74,7 @@ function checkMissionStatus() {
 // 랭크 정보 로드
 function loadRankInfo() {
     $.ajax({
-        url: cpath + '/mission/status',
+        url: cpath + '/api/mission/user-rank',
         type: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/src/main/webapp/resources/js/mission/mission.js
+++ b/src/main/webapp/resources/js/mission/mission.js
@@ -42,7 +42,7 @@ function checkMissionStatus() {
             $('#news-count-text').text(`(${newsCount}/5)`);
 
             // 퀴즈 미션 카드 상태 업데이트
-            if (data.isQuizCompleted) {
+            if (data.quizCompleted) {
                 const $quizCard = $('#mission-card-quiz');
                 $quizCard.addClass('completed');
 
@@ -54,7 +54,7 @@ function checkMissionStatus() {
             }
 
             // 뉴스 미션 카드 상태 업데이트
-            if (data.isNewsCompleted) {
+            if (data.newsCompleted) {
                 const $newsCard = $('#mission-card-news');
                 $newsCard.addClass('completed');
 

--- a/src/main/webapp/resources/js/news/news.js
+++ b/src/main/webapp/resources/js/news/news.js
@@ -10,7 +10,7 @@ $(document).ready(function() {
 
 function loadNews(page) {
     $.ajax({
-        url: `${cpath}/api/news`,
+        url: `${cpath}/api/naver/news`,
         method: 'GET',
         data: {
             page: page,
@@ -107,7 +107,7 @@ function handleNewsClick(url, cardElement) {
 
     // 서버에 읽음 기록 요청
     $.ajax({
-        url: `${cpath}/api/news/read`,
+        url: `${cpath}/api/mission/news/read`,
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify({ newsUrl: url }),
@@ -156,7 +156,7 @@ function changePage(page) {
 // 미션 진행률 로딩
 function loadMissionProgress() {
     $.ajax({
-        url: `${cpath}/api/news/progress`,
+        url: `${cpath}/api/mission/news/progress`,
         type: 'GET',
         dataType: 'json',
         success: function(data) {

--- a/src/main/webapp/resources/js/quiz/quiz.js
+++ b/src/main/webapp/resources/js/quiz/quiz.js
@@ -20,13 +20,13 @@ function formatTodayKorean() {
 // 서버 API 호출하여 데이터 가져오기
 function getDailyQuiz() {
     $.ajax({
-        url: cpath + "/mission/today-status",
+        url: cpath + "/api/mission/today-progress",
         type: 'GET',
         dataType: 'json',
         success: function (statusData) {
             correctAnswers = statusData.quizCount || 0;
             $.ajax({
-                url: cpath + '/mission/daily',
+                url: cpath + '/api/mission/quiz/daily',
                 type: 'GET',
                 dataType: 'json',
                 success: function (data) {
@@ -199,7 +199,7 @@ function submitAnswer(quizId, optionId, buttonElement) {
         choiceNo : optionId
     }
     $.ajax({
-        url: cpath + '/mission/check',
+        url: cpath + '/api/mission/quiz/check',
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify(requestData),

--- a/src/main/webapp/resources/js/quiz/quiz.js
+++ b/src/main/webapp/resources/js/quiz/quiz.js
@@ -111,7 +111,7 @@ function handleCorrectAnswer(buttonElement, optionId, response) {
     correctAnswers++;
 
     // 정답 모달 표시
-    showCorrectModal(response.point, response.message);
+    showResultModal(true, response.point, response.message);
 
     // 진행률 업데이트
     updateProgress();
@@ -122,7 +122,7 @@ function handleWrongAnswer(buttonElement, message) {
     buttonElement.classList.add('wrong');
 
     // 오답 모달 표시
-    showWrongModal(message);
+    showResultModal(false, 0, message);
 
     // 1초 후 원래 상태로
     setTimeout(() => {
@@ -144,38 +144,25 @@ function updateProgress() {
     document.getElementById('quiz-progressStatus').textContent = progress + '% 달성!';
 }
 
-// 정답 모달 표시
-function showCorrectModal(point, explanation) {
+// 결과 모달 표시
+function showResultModal(isCorrect, point, message) {
     const modal = document.getElementById('quiz-result-Modal');
     const pointsMessage = document.getElementById('quiz-pointsMessage');
     const modalTitle = modal.querySelector('.quiz-modal-title');
     const modalMessage = modal.querySelector('.quiz-modal-message');
 
-    // 포인트 메시지 표시
-    pointsMessage.textContent = point + ' 포인트를 획득하였습니다.';
-    pointsMessage.style.display = 'block';
-
-    modalTitle.textContent = '짝짝짝👏👏👏 정답입니다~';
-    modalMessage.textContent = explanation;
-
-    // 정답 스타일 추가
-    modal.classList.add('correct');
-    modal.classList.add('active');
-}
-
-// 오답 모달 표시
-function showWrongModal(message) {
-    const modal = document.getElementById('quiz-result-Modal');
-    const pointsMessage = document.getElementById('quiz-pointsMessage');
-    const modalTitle = modal.querySelector('.quiz-modal-title');
-    const modalMessage = modal.querySelector('.quiz-modal-message');
-
-    pointsMessage.style.display = 'none';
-    modalTitle.textContent = message; // "다시 한번 생각해 보세요."
-    modalMessage.textContent = '퀴즈를 맞히고 나의 개미 랭크를 높여보세요!';
-
-    // 정답 스타일 제거
-    modal.classList.remove('correct');
+    if (isCorrect) {
+        modal.classList.add('correct');
+        pointsMessage.textContent = point + ' 포인트를 획득하였습니다.';
+        pointsMessage.style.display = 'block';
+        modalTitle.textContent = '짝짝짝👏👏👏 정답입니다~';
+        modalMessage.textContent = message;
+    } else {
+        modal.classList.remove('correct');
+        pointsMessage.style.display = 'none';
+        modalTitle.textContent = message; // "다시 한번 생각해 보세요."
+        modalMessage.textContent = '퀴즈를 맞히고 나의 개미 랭크를 높여보세요!';
+    }
     modal.classList.add('active');
 }
 

--- a/src/main/webapp/resources/js/quiz/quiz.js
+++ b/src/main/webapp/resources/js/quiz/quiz.js
@@ -194,7 +194,6 @@ function closeModal() {
 // 정답 제출 (AJAX)
 function submitAnswer(quizId, optionId, buttonElement) {
     const requestData = {
-        userId : currentUserId,
         quizId : quizId,
         choiceNo : optionId
     }


### PR DESCRIPTION
## 🔗 연결된 Issue
> 연결된 issue를 자동으로 닫기 위해 아래 이슈 넘버를 입력해주세요.

- close #253

---

### 📝 작업 내용
1. 도메인 및 컨트롤러 분리
- Mission에 종속되어 있던 퀴즈 기능을 분리했습니다.
- News 역할 분담: 하나의 컨트롤러에 섞여 있던 로직을 두 개로 쪼개어 역할을 분리 했습니다.
  - NaverNewsController: 네이버 뉴스 API 조회 및 데이터 가공
  - NewsController: 사용자의 뉴스 읽기 기록 및 포인트 적립

2. 보안 강화
- JS에서 userId를 파라미터로 보내던 방식을 제거했습니다.
- Service 내부가 아닌 Controller에서 SecurityContextHolder를 통해 세션 ID를 추출하여 주입하도록 변경했습니다.

3. 데이터 구조 개선 (Map -> DTO)
- Map<String, Object>로 반환하던 불명확한 응답 구조를 DTO로 변경하였습니다.

4. 의존성 제거
- NaverNewsController가 MissionService에 의존하던 구조를 제거하고 각 컨트롤러가 독립적으로 동작하도록 개선했습니다.

---

### 📷 스크린샷 (선택)
- UI 변경 사항이 있다면 첨부

---

### 💬 리뷰 요구사항 (선택)
- 리뷰어가 중점적으로 봐줬으면 하는 부분

---

## ✅ 체크리스트
- [ ] PR 제목 규칙을 지켰다
- [ ] 추가/수정 사항을 설명했다
- [ ] 이슈 번호를 연결했다
